### PR TITLE
feat: refresh login landing page

### DIFF
--- a/src/assets/images/background/data-platform-tech.svg
+++ b/src/assets/images/background/data-platform-tech.svg
@@ -1,0 +1,83 @@
+<svg width="1440" height="1080" viewBox="0 0 1440 1080" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bgGradient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(720 324) rotate(90) scale(756 1040)">
+      <stop offset="0" stop-color="#1F5BFF" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#050914"/>
+    </radialGradient>
+    <radialGradient id="halo" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(720 540) rotate(90) scale(220 480)">
+      <stop offset="0" stop-color="#4DA9FF" stop-opacity="0.7"/>
+      <stop offset="1" stop-color="#0A1935" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="platform" x1="480" y1="720" x2="960" y2="720" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2F82FF"/>
+      <stop offset="1" stop-color="#6AE6FF"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="720" y1="420" x2="720" y2="780" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#63C6FF" stop-opacity="0"/>
+      <stop offset="0.5" stop-color="#63C6FF" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#63C6FF" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="stream" x1="200" y1="200" x2="1240" y2="880" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#3265FF" stop-opacity="0"/>
+      <stop offset="0.45" stop-color="#58D6FF" stop-opacity="0.7"/>
+      <stop offset="1" stop-color="#6AF9F7" stop-opacity="0"/>
+    </linearGradient>
+    <filter id="glow" x="-200" y="-200" width="1840" height="1480" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="80" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="screen"/>
+    </filter>
+    <filter id="nodeGlow" x="-40" y="-40" width="120" height="120" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="12" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="screen"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="1080" fill="#040B1C"/>
+  <rect width="1440" height="1080" fill="url(#bgGradient)"/>
+  <ellipse cx="720" cy="560" rx="420" ry="160" fill="url(#halo)"/>
+  <g stroke="url(#stream)" stroke-width="2" stroke-linecap="round" stroke-dasharray="6 16">
+    <path d="M160 760C280 640 520 620 720 540C920 460 1120 300 1260 220"/>
+    <path d="M180 380C360 460 480 520 720 520C960 520 1120 520 1260 640"/>
+    <path d="M200 960C360 840 520 820 720 760C920 700 1120 580 1240 420"/>
+  </g>
+  <g filter="url(#glow)">
+    <ellipse cx="720" cy="748" rx="300" ry="60" fill="#0F1A3A" opacity="0.8"/>
+    <ellipse cx="720" cy="748" rx="300" ry="60" fill="url(#ring)"/>
+  </g>
+  <g>
+    <ellipse cx="720" cy="720" rx="240" ry="40" fill="#061433" opacity="0.8"/>
+    <ellipse cx="720" cy="718" rx="240" ry="42" stroke="#2F82FF" stroke-opacity="0.35" stroke-width="2"/>
+    <rect x="520" y="560" width="400" height="110" rx="40" fill="#081D4D" stroke="#3EA3FF" stroke-opacity="0.6" stroke-width="1.5"/>
+    <rect x="560" y="590" width="320" height="50" rx="20" fill="url(#platform)" opacity="0.9"/>
+    <g opacity="0.9">
+      <rect x="600" y="600" width="16" height="30" rx="4" fill="#0A1F52"/>
+      <rect x="624" y="596" width="16" height="36" rx="4" fill="#4CD9FF"/>
+      <rect x="648" y="602" width="16" height="28" rx="4" fill="#23A8FF"/>
+      <rect x="672" y="594" width="16" height="36" rx="4" fill="#51E2FF"/>
+      <rect x="696" y="598" width="16" height="32" rx="4" fill="#0A1F52"/>
+      <rect x="720" y="592" width="16" height="38" rx="4" fill="#23A8FF"/>
+      <rect x="744" y="602" width="16" height="28" rx="4" fill="#4CD9FF"/>
+      <rect x="768" y="596" width="16" height="34" rx="4" fill="#23A8FF"/>
+      <rect x="792" y="604" width="16" height="26" rx="4" fill="#0A1F52"/>
+    </g>
+    <circle cx="720" cy="548" r="86" stroke="#4FD8FF" stroke-width="3" opacity="0.4"/>
+    <circle cx="720" cy="548" r="66" stroke="#4FD8FF" stroke-width="2" opacity="0.5"/>
+    <circle cx="720" cy="548" r="46" fill="#0F2B63" opacity="0.8"/>
+    <path d="M720 486C737.673 486 754.426 492.856 767.426 505.426C780.426 517.996 787.5 535.077 787.5 553C787.5 570.923 780.426 588.004 767.426 600.574C754.426 613.144 737.673 620 720 620C702.327 620 685.574 613.144 672.574 600.574C659.574 588.004 652.5 570.923 652.5 553C652.5 535.077 659.574 517.996 672.574 505.426C685.574 492.856 702.327 486 720 486Z" stroke="#63F5FF" stroke-opacity="0.6" stroke-width="2"/>
+    <path d="M720 516C732.967 516 744.934 521.151 753.434 529.566C761.935 537.981 766.5 549.024 766.5 560.5C766.5 571.976 761.935 583.019 753.434 591.434C744.934 599.849 732.967 605 720 605C707.033 605 695.066 599.849 686.566 591.434C678.065 583.019 673.5 571.976 673.5 560.5C673.5 549.024 678.065 537.981 686.566 529.566C695.066 521.151 707.033 516 720 516Z" stroke="#4CD9FF" stroke-width="2" opacity="0.8"/>
+    <circle cx="720" cy="548" r="24" fill="#63F5FF" opacity="0.4"/>
+    <circle cx="720" cy="548" r="12" fill="#E7FAFF"/>
+  </g>
+  <g filter="url(#nodeGlow)" opacity="0.9">
+    <circle cx="280" cy="320" r="10" fill="#63F5FF"/>
+    <circle cx="1180" cy="280" r="12" fill="#3EA3FF"/>
+    <circle cx="1120" cy="820" r="10" fill="#63F5FF"/>
+    <circle cx="320" cy="880" r="10" fill="#3EA3FF"/>
+    <circle cx="980" cy="460" r="8" fill="#51E2FF"/>
+    <circle cx="420" cy="520" r="8" fill="#51E2FF"/>
+  </g>
+  <g stroke="#3EA3FF" stroke-opacity="0.24" stroke-width="1.2">
+    <path d="M220 240C420 340 520 420 720 420C920 420 1030 320 1240 220"/>
+    <path d="M200 660C340 640 560 600 720 660C880 720 1060 800 1240 780"/>
+    <path d="M240 520C400 500 520 520 720 500C920 480 1080 420 1220 440"/>
+  </g>
+</svg>

--- a/src/locales/lang/en_US/sys.json
+++ b/src/locales/lang/en_US/sys.json
@@ -25,6 +25,7 @@
 		},
 		"docs": "Document",
 		"login": {
+			"brandTitle": "Data Platform Manager",
 			"accountPlaceholder": "Please input username",
 			"backSignIn": "Back sign in",
 			"confirmPassword": "Confirm Password",

--- a/src/locales/lang/zh_CN/sys.json
+++ b/src/locales/lang/zh_CN/sys.json
@@ -25,6 +25,7 @@
 			"errMsg505": "http版本不支持该请求!"
 		},
 		"login": {
+			"brandTitle": "数据管理平台(密级)",
 			"backSignIn": "返回",
 			"signInFormTitle": "登录到您的账户",
 			"mobileSignInFormTitle": "手机登录",

--- a/src/pages/sys/login/index.tsx
+++ b/src/pages/sys/login/index.tsx
@@ -1,10 +1,11 @@
-import PlaceholderImg from "@/assets/images/background/placeholder.svg";
+import DataPlatformImg from "@/assets/images/background/data-platform-tech.svg";
+import { Icon } from "@/components/icon";
 import LocalePicker from "@/components/locale-picker";
-import Logo from "@/components/logo";
 import { GLOBAL_CONFIG } from "@/global-config";
 import SettingButton from "@/layouts/components/setting-button";
 import { useUserToken } from "@/store/userStore";
 import { Navigate } from "react-router";
+import { useTranslation } from "react-i18next";
 import LoginForm from "./login-form";
 import MobileForm from "./mobile-form";
 import { LoginProvider } from "./providers/login-provider";
@@ -13,6 +14,7 @@ import RegisterForm from "./register-form";
 import ResetForm from "./reset-form";
 
 function LoginPage() {
+	const { t } = useTranslation();
 	const token = useUserToken();
 
 	if (token.accessToken) {
@@ -23,9 +25,9 @@ function LoginPage() {
 		<div className="relative grid min-h-svh lg:grid-cols-2 bg-background">
 			<div className="flex flex-col gap-4 p-6 md:p-10">
 				<div className="flex justify-center gap-2 md:justify-start">
-					<div className="flex items-center gap-2 font-medium cursor-pointer">
-						<Logo size={28} />
-						<span>{GLOBAL_CONFIG.appName}</span>
+					<div className="flex items-center gap-2 text-xl font-semibold text-foreground">
+						<Icon icon="lucide:star" size={28} className="text-primary" />
+						<span>{t("sys.login.brandTitle")}</span>
 					</div>
 				</div>
 				<div className="flex flex-1 items-center justify-center">
@@ -42,7 +44,11 @@ function LoginPage() {
 			</div>
 
 			<div className="relative hidden bg-background-paper lg:block">
-				<img src={PlaceholderImg} alt="placeholder img" className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.5] dark:grayscale" />
+				<img
+					src={DataPlatformImg}
+					alt="technology driven data platform illustration"
+					className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.5] dark:grayscale"
+				/>
 			</div>
 
 			<div className="absolute right-2 top-0 flex flex-row">

--- a/src/pages/sys/login/login-form.tsx
+++ b/src/pages/sys/login/login-form.tsx
@@ -86,24 +86,19 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
 						)}
 					/>
 
-					{/* 记住我/忘记密码 */}
-					<div className="flex flex-row justify-between">
-						<div className="flex items-center space-x-2">
-							<Checkbox
-								id="remember"
-								checked={remember}
-								onCheckedChange={(checked) => setRemember(checked === "indeterminate" ? false : checked)}
-							/>
-							<label
-								htmlFor="remember"
-								className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-							>
-								{t("sys.login.rememberMe")}
-							</label>
-						</div>
-						<Button variant="link" onClick={() => setLoginState(LoginStateEnum.RESET_PASSWORD)} size="sm">
-							{t("sys.login.forgetPassword")}
-						</Button>
+					{/* 记住我 */}
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							id="remember"
+							checked={remember}
+							onCheckedChange={(checked) => setRemember(checked === "indeterminate" ? false : checked)}
+						/>
+						<label
+							htmlFor="remember"
+							className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+						>
+							{t("sys.login.rememberMe")}
+						</label>
 					</div>
 
 					{/* 登录按钮 */}
@@ -137,14 +132,6 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
 						</Button>
 						<Button variant="ghost" size="icon">
 							<Icon icon="ant-design:google-circle-filled" size={24} />
-						</Button>
-					</div>
-
-					{/* 注册 */}
-					<div className="text-center text-sm">
-						{t("sys.login.noAccount")}
-						<Button variant="link" className="px-1" onClick={() => setLoginState(LoginStateEnum.REGISTER)}>
-							{t("sys.login.signUpFormTitle")}
 						</Button>
 					</div>
 				</form>


### PR DESCRIPTION
## Summary
- replace the login header title with a star icon and localized platform name strings
- remove the forgotten password link and registration prompt from the sign-in form
- add a new big-data themed illustration to the login page hero

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cc97c8cf8c8329833c983dfc857471