### PR TITLE
feat: refresh login page branding and visuals

### DIFF
--- a/src/assets/images/background/tech-data-platform.svg
+++ b/src/assets/images/background/tech-data-platform.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1200" viewBox="0 0 1200 1200" fill="none">
+  <defs>
+    <linearGradient id="bgGradient" x1="1200" y1="0" x2="0" y2="1200" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#041836" />
+      <stop offset="1" stop-color="#240A3C" />
+    </linearGradient>
+    <radialGradient id="centerGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(600 620) scale(520)">
+      <stop offset="0" stop-color="#3ABFF8" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#041836" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="gridStroke" x1="0" y1="0" x2="1200" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6B9AFF" stop-opacity="0" />
+      <stop offset="0.5" stop-color="#6B9AFF" stop-opacity="0.35" />
+      <stop offset="1" stop-color="#6B9AFF" stop-opacity="0" />
+    </linearGradient>
+    <linearGradient id="orbitStroke" x1="600" y1="220" x2="600" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7C3AED" stop-opacity="0.1" />
+      <stop offset="0.5" stop-color="#A855F7" stop-opacity="0.5" />
+      <stop offset="1" stop-color="#60A5FA" stop-opacity="0.1" />
+    </linearGradient>
+    <radialGradient id="nodeGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(18)">
+      <stop offset="0" stop-color="#E0F2FE" />
+      <stop offset="1" stop-color="#0284C7" stop-opacity="0" />
+    </radialGradient>
+    <filter id="cardShadow" x="-20" y="-20" width="164" height="164" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feGaussianBlur in="SourceAlpha" stdDeviation="12" result="blur" />
+      <feOffset dy="6" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.35 0 0 0 0 1 0 0 0 0.25 0" />
+      <feBlend in2="BackgroundImageFix" result="effect1_dropShadow" />
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+    </filter>
+  </defs>
+  <rect width="1200" height="1200" rx="32" fill="url(#bgGradient)" />
+  <rect width="1200" height="1200" fill="url(#centerGlow)" />
+  <g stroke="url(#gridStroke)" stroke-width="1.5">
+    <path d="M150 0V1200" />
+    <path d="M350 0V1200" />
+    <path d="M550 0V1200" />
+    <path d="M750 0V1200" />
+    <path d="M950 0V1200" />
+    <path d="M0 220H1200" />
+    <path d="M0 420H1200" />
+    <path d="M0 620H1200" />
+    <path d="M0 820H1200" />
+    <path d="M0 1020H1200" />
+  </g>
+  <circle cx="600" cy="620" r="260" stroke="url(#orbitStroke)" stroke-width="3" />
+  <circle cx="600" cy="620" r="180" stroke="url(#orbitStroke)" stroke-width="2" stroke-dasharray="16 16" />
+  <circle cx="600" cy="620" r="120" stroke="#22D3EE" stroke-opacity="0.35" stroke-width="1.5" stroke-dasharray="8 12" />
+  <g opacity="0.85">
+    <path d="M360 480C430 420 520 400 600 420C680 440 780 520 840 600" stroke="#38BDF8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M420 820C470 740 540 700 630 700C720 700 820 760 880 840" stroke="#22D3EE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M320 660C370 580 470 540 560 560C650 580 720 640 780 720" stroke="#A855F7" stroke-opacity="0.6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+  <g>
+    <circle cx="360" cy="480" r="6" fill="#38BDF8" />
+    <circle cx="600" cy="420" r="8" fill="#22D3EE" />
+    <circle cx="840" cy="600" r="10" fill="#A855F7" />
+    <circle cx="420" cy="820" r="7" fill="#38BDF8" />
+    <circle cx="630" cy="700" r="9" fill="#22D3EE" />
+    <circle cx="880" cy="840" r="6" fill="#A855F7" />
+    <circle cx="320" cy="660" r="6" fill="#38BDF8" />
+    <circle cx="780" cy="720" r="7" fill="#22D3EE" />
+  </g>
+  <g>
+    <path d="M520 520L600 600L704 516" stroke="#60A5FA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M520 520L520 640L632 752" stroke="#A855F7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M704 516L840 520" stroke="#34D399" stroke-opacity="0.6" stroke-width="2" stroke-linecap="round" />
+    <path d="M632 752L760 880" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" />
+  </g>
+  <g opacity="0.8">
+    <circle cx="520" cy="520" r="18" fill="url(#nodeGlow)" />
+    <circle cx="600" cy="600" r="28" fill="url(#nodeGlow)" />
+    <circle cx="704" cy="516" r="16" fill="url(#nodeGlow)" />
+    <circle cx="632" cy="752" r="18" fill="url(#nodeGlow)" />
+    <circle cx="840" cy="520" r="20" fill="url(#nodeGlow)" />
+    <circle cx="760" cy="880" r="18" fill="url(#nodeGlow)" />
+  </g>
+  <g filter="url(#cardShadow)" transform="translate(240 320)">
+    <rect width="124" height="124" rx="20" fill="rgba(15, 23, 42, 0.75)" stroke="rgba(96, 165, 250, 0.35)" stroke-width="1.5" />
+    <path d="M28 88C48 70 76 70 96 88" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" />
+    <path d="M28 60C44 50 72 52 96 64" stroke="#A855F7" stroke-width="2" stroke-linecap="round" stroke-dasharray="6 8" />
+    <circle cx="40" cy="40" r="8" fill="#22D3EE" />
+    <circle cx="84" cy="38" r="6" fill="#F97316" />
+  </g>
+  <g filter="url(#cardShadow)" transform="translate(836 360)">
+    <rect width="124" height="124" rx="20" fill="rgba(15, 23, 42, 0.78)" stroke="rgba(168, 85, 247, 0.35)" stroke-width="1.5" />
+    <path d="M36 92L52 68L72 84L92 60" stroke="#A855F7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M36 52L52 72L72 46L92 70" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="36" cy="92" r="6" fill="#34D399" />
+    <circle cx="52" cy="68" r="6" fill="#38BDF8" />
+    <circle cx="72" cy="84" r="6" fill="#A855F7" />
+    <circle cx="92" cy="60" r="6" fill="#FACC15" />
+  </g>
+  <g transform="translate(420 860)">
+    <rect x="-24" y="-24" width="240" height="120" rx="28" fill="rgba(15, 23, 42, 0.7)" stroke="rgba(96, 165, 250, 0.35)" stroke-width="1.5" />
+    <path d="M0 40H192" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-dasharray="10 12" />
+    <path d="M16 16H80V64H16V16Z" fill="rgba(59, 130, 246, 0.2)" stroke="#60A5FA" stroke-width="1.5" rx="8" />
+    <path d="M112 16H176V64H112V16Z" fill="rgba(14, 165, 233, 0.2)" stroke="#22D3EE" stroke-width="1.5" rx="8" />
+    <path d="M32 28H64V52H32V28Z" fill="#38BDF8" opacity="0.45" />
+    <path d="M128 28H160V52H128V28Z" fill="#22D3EE" opacity="0.45" />
+  </g>
+</svg>

--- a/src/locales/lang/en_US/sys.json
+++ b/src/locales/lang/en_US/sys.json
@@ -25,6 +25,8 @@
 		},
 		"docs": "Document",
 		"login": {
+			"brandName": "Data Platform Manager",
+			"brandIllustrationAlt": "Futuristic data platform illustration",
 			"accountPlaceholder": "Please input username",
 			"backSignIn": "Back sign in",
 			"confirmPassword": "Confirm Password",

--- a/src/locales/lang/zh_CN/sys.json
+++ b/src/locales/lang/zh_CN/sys.json
@@ -24,6 +24,8 @@
 			"errMsg505": "http版本不支持该请求!"
 		},
 		"login": {
+			"brandName": "数据管理平台(密级)",
+			"brandIllustrationAlt": "科技氛围大数据平台插画",
 			"backSignIn": "返回",
 			"signInFormTitle": "登录到您的账户",
 			"mobileSignInFormTitle": "手机登录",

--- a/src/pages/management/system/auditlog/index.tsx
+++ b/src/pages/management/system/auditlog/index.tsx
@@ -1,12 +1,12 @@
 import { Button, Modal, Table, Tag, Tooltip } from "antd";
 import type { ColumnsType } from "antd/es/table";
+import { Eye } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import type { AuditLog } from "#/entity";
 import { AuditLogService } from "@/api/services/auditLogService";
 import { Card, CardContent, CardHeader } from "@/ui/card";
 import { Text } from "@/ui/typography";
-import { EyeOutlined } from "@ant-design/icons";
 
 export default function AuditLogPage() {
 	const [loading, setLoading] = useState(false);
@@ -107,7 +107,7 @@ export default function AuditLogPage() {
 			key: "action",
 			width: 100,
 			render: (_, record) => (
-				<Button type="link" icon={<EyeOutlined />} onClick={() => handleViewDetail(record)}>
+				<Button type="link" icon={<Eye className="h-4 w-4" />} onClick={() => handleViewDetail(record)}>
 					查看详情
 				</Button>
 			),

--- a/src/pages/sys/login/index.tsx
+++ b/src/pages/sys/login/index.tsx
@@ -1,7 +1,6 @@
 import { Navigate } from "react-router";
-import PlaceholderImg from "@/assets/images/background/placeholder.svg";
+import TechDataBackground from "@/assets/images/background/tech-data-platform.svg";
 import LocalePicker from "@/components/locale-picker";
-import Logo from "@/components/logo";
 import { GLOBAL_CONFIG } from "@/global-config";
 import SettingButton from "@/layouts/components/setting-button";
 import { useUserToken } from "@/store/userStore";
@@ -9,21 +8,29 @@ import LoginForm from "./login-form";
 import { LoginProvider } from "./providers/login-provider";
 import RegisterForm from "./register-form";
 import ResetForm from "./reset-form";
+import { Star } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 function LoginPage() {
 	const token = useUserToken();
+	const { t, i18n } = useTranslation();
 
 	if (token.accessToken) {
 		return <Navigate to={GLOBAL_CONFIG.defaultRoute} replace />;
 	}
 
+	const brandLabel = i18n.language?.toLowerCase().startsWith("zh") ? "数据管理平台(密级)" : "Data Platform Manager";
+	const brandLabelFromLocale = t("sys.login.brandName", {
+		defaultValue: brandLabel,
+	});
+
 	return (
 		<div className="relative grid min-h-svh lg:grid-cols-2 bg-background">
 			<div className="flex flex-col gap-4 p-6 md:p-10">
 				<div className="flex justify-center gap-2 md:justify-start">
-					<div className="flex items-center gap-2 font-medium cursor-pointer">
-						<Logo size={28} />
-						<span>{GLOBAL_CONFIG.appName}</span>
+					<div className="flex items-center gap-3 font-medium cursor-default">
+						<Star className="h-8 w-8 text-primary" fill="currentColor" strokeWidth={1.5} />
+						<span className="text-lg font-semibold leading-tight text-foreground">{brandLabelFromLocale}</span>
 					</div>
 				</div>
 				<div className="flex flex-1 items-center justify-center">
@@ -39,8 +46,10 @@ function LoginPage() {
 
 			<div className="relative hidden bg-background-paper lg:block">
 				<img
-					src={PlaceholderImg}
-					alt="placeholder img"
+					src={TechDataBackground}
+					alt={t("sys.login.brandIllustrationAlt", {
+						defaultValue: "Futuristic data platform visualization",
+					})}
 					className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.5] dark:grayscale"
 				/>
 			</div>

--- a/src/pages/sys/login/login-form.tsx
+++ b/src/pages/sys/login/login-form.tsx
@@ -20,7 +20,7 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
 	const [remember, setRemember] = useState(true);
 	const navigate = useNavigate();
 
-	const { loginState, setLoginState } = useLoginStateContext();
+	const { loginState } = useLoginStateContext();
 	const signIn = useSignIn();
 
 	const form = useForm<SignInReq>({
@@ -88,8 +88,8 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
 						)}
 					/>
 
-					{/* 记住我/忘记密码 */}
-					<div className="flex flex-row justify-between">
+					{/* 记住我 */}
+					<div className="flex flex-row justify-start">
 						<div className="flex items-center space-x-2">
 							<Checkbox
 								id="remember"
@@ -103,9 +103,6 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
 								{t("sys.login.rememberMe")}
 							</label>
 						</div>
-						<Button variant="link" onClick={() => setLoginState(LoginStateEnum.RESET_PASSWORD)} size="sm">
-							{t("sys.login.forgetPassword")}
-						</Button>
 					</div>
 
 					{/* 登录按钮 */}
@@ -113,14 +110,6 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
 						{loading && <Loader2 className="animate-spin mr-2" />}
 						{t("sys.login.loginButton")}
 					</Button>
-
-					{/* 注册 */}
-					<div className="text-center text-sm">
-						{t("sys.login.noAccount")}
-						<Button variant="link" className="px-1" onClick={() => setLoginState(LoginStateEnum.REGISTER)}>
-							{t("sys.login.signUpFormTitle")}
-						</Button>
-					</div>
 				</form>
 			</Form>
 		</div>


### PR DESCRIPTION
## Summary
- replace the login header brand with a star icon and locale-aware platform name
- remove the forgot password/register prompts and introduce a new tech-inspired illustration on the login page
- switch the audit log detail action to the lucide eye icon to avoid missing ant-design icon types

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cc9af115b883298413796c60fa06a7