### PR TITLE
feat: add organization crud management

### DIFF
--- a/src/_mock/handlers/_admin.ts
+++ b/src/_mock/handlers/_admin.ts
@@ -6,6 +6,7 @@ import type {
 	AuditEvent,
 	ChangeRequest,
 	OrganizationNode,
+	OrganizationPayload,
 	PermissionCatalogSection,
 	PortalMenuItem,
 	SystemConfigItem,
@@ -54,7 +55,7 @@ const systemConfigs: SystemConfigItem[] = [
 	{ id: 3, key: "airflow.deployment", value: "v2.9.0", description: "调度集群版本" },
 ];
 
-let portalMenus: PortalMenuItem[] = [
+const portalMenus: PortalMenuItem[] = [
 	{
 		id: 1,
 		name: "数据总览",
@@ -84,51 +85,169 @@ const organizations: OrganizationNode[] = [
 	{
 		id: 1,
 		name: "数据与智能中心",
-		code: "DIC",
-		leader: "李雷",
-		memberCount: 48,
-		sensitivity: "TOP_SECRET",
-		securityDomains: ["机密", "秘密"],
+		dataLevel: "DATA_TOP_SECRET",
+		sensitivity: "DATA_TOP_SECRET",
+		contact: "李雷",
+		phone: "13800000001",
+		description: "统筹企业数据治理、开发与运营能力",
+		parentId: null,
 		children: [
 			{
 				id: 2,
 				name: "数据平台组",
-				code: "DPF",
-				leader: "韩梅",
-				memberCount: 18,
-				sensitivity: "SECRET",
-				description: "负责 Iceberg、MinIO 等基础平台",
+				dataLevel: "DATA_SECRET",
+				sensitivity: "DATA_SECRET",
+				contact: "韩梅",
+				phone: "13800000002",
+				description: "负责数据平台建设与稳定性",
+				parentId: 1,
 				children: [
 					{
 						id: 3,
 						name: "数据运维团队",
-						code: "OPS",
-						leader: "陈伟",
-						memberCount: 8,
-						sensitivity: "NORMAL",
+						dataLevel: "DATA_INTERNAL",
+						sensitivity: "DATA_INTERNAL",
+						contact: "陈伟",
+						phone: "021-88886666",
+						description: "保障数据基础设施运行",
+						parentId: 2,
+					},
+					{
+						id: 5,
+						name: "研发支持团队",
+						dataLevel: "DATA_PUBLIC",
+						sensitivity: "DATA_PUBLIC",
+						contact: "赵敏",
+						phone: "13800000005",
+						description: "提供平台接入与研发支持",
+						parentId: 2,
 					},
 				],
 			},
 			{
 				id: 4,
 				name: "数据治理组",
-				code: "GOV",
-				leader: "王雪",
-				memberCount: 12,
-				sensitivity: "SECRET",
-				securityDomains: ["秘密"],
+				dataLevel: "DATA_SECRET",
+				sensitivity: "DATA_SECRET",
+				contact: "王雪",
+				phone: "13800000003",
+				description: "制定数据标准与安全策略",
+				parentId: 1,
 			},
 		],
 	},
 	{
 		id: 10,
 		name: "业务数据中心",
-		code: "BDC",
-		leader: "赵强",
-		memberCount: 60,
-		sensitivity: "SECRET",
+		dataLevel: "DATA_SECRET",
+		sensitivity: "DATA_SECRET",
+		contact: "赵强",
+		phone: "010-55556666",
+		description: "面向业务线的数据服务支撑",
+		parentId: null,
+		children: [
+			{
+				id: 11,
+				name: "客户洞察部",
+				dataLevel: "DATA_INTERNAL",
+				sensitivity: "DATA_INTERNAL",
+				contact: "孙丽",
+				phone: "010-88889999",
+				description: "提供客户全域分析能力",
+				parentId: 10,
+			},
+		],
 	},
 ];
+
+let organizationId = 20;
+
+function findOrganization(nodes: OrganizationNode[], id: number): OrganizationNode | null {
+	for (const node of nodes) {
+		if (node.id === id) {
+			return node;
+		}
+		if (node.children?.length) {
+			const found = findOrganization(node.children, id);
+			if (found) {
+				return found;
+			}
+		}
+	}
+	return null;
+}
+
+function insertOrganization(nodes: OrganizationNode[], parentId: number | null, node: OrganizationNode): boolean {
+	if (parentId == null) {
+		node.parentId = null;
+		nodes.push(node);
+		return true;
+	}
+	for (const item of nodes) {
+		if (item.id === parentId) {
+			node.parentId = parentId;
+			if (item.children) {
+				item.children.push(node);
+			} else {
+				item.children = [node];
+			}
+			return true;
+		}
+		if (item.children?.length && insertOrganization(item.children, parentId, node)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function updateOrganizationNode(
+	nodes: OrganizationNode[],
+	id: number,
+	patch: Partial<OrganizationNode>,
+): OrganizationNode | null {
+	for (const node of nodes) {
+		if (node.id === id) {
+			const sanitized: Partial<OrganizationNode> = {};
+			for (const [key, value] of Object.entries(patch) as [
+				keyof OrganizationNode,
+				OrganizationNode[keyof OrganizationNode],
+			][]) {
+				if (value !== undefined) {
+					(sanitized as Record<string, unknown>)[key as string] = value as unknown;
+				}
+			}
+			Object.assign(node, sanitized);
+			if (sanitized.dataLevel) {
+				node.sensitivity = sanitized.dataLevel;
+			}
+			return node;
+		}
+		if (node.children?.length) {
+			const updated = updateOrganizationNode(node.children, id, patch);
+			if (updated) {
+				return updated;
+			}
+		}
+	}
+	return null;
+}
+
+function deleteOrganizationNode(nodes: OrganizationNode[], id: number): boolean {
+	const index = nodes.findIndex((item) => item.id === id);
+	if (index !== -1) {
+		nodes.splice(index, 1);
+		return true;
+	}
+	for (const node of nodes) {
+		if (node.children?.length && deleteOrganizationNode(node.children, id)) {
+			if (node.children.length === 0) {
+				delete node.children;
+			}
+			return true;
+		}
+	}
+	return false;
+}
 
 const adminUsers: AdminUser[] = Array.from({ length: 24 }).map((_, index) => {
 	const status = faker.helpers.arrayElement(["ACTIVE", "PENDING", "DISABLED"]);
@@ -138,7 +257,10 @@ const adminUsers: AdminUser[] = Array.from({ length: 24 }).map((_, index) => {
 		displayName: faker.person.fullName(),
 		email: faker.internet.email(),
 		orgPath: faker.helpers.arrayElements(["数据与智能中心", "数据平台组", "业务线A", "业务线B"], { min: 1, max: 3 }),
-		roles: faker.helpers.arrayElements(["SYSADMIN", "AUTHADMIN", "AUDITADMIN", "DATA_STEWARD", "DATA_ANALYST"], { min: 1, max: 2 }),
+		roles: faker.helpers.arrayElements(["SYSADMIN", "AUTHADMIN", "AUDITADMIN", "DATA_STEWARD", "DATA_ANALYST"], {
+			min: 1,
+			max: 2,
+		}),
 		securityLevel: faker.helpers.arrayElement(["非密", "普通", "秘密", "机密"]),
 		status,
 		lastLoginAt: status === "DISABLED" ? undefined : faker.date.recent({ days: 6 }).toISOString(),
@@ -238,57 +360,57 @@ export const adminHandlers = [
 	http.post(`${ADMIN_API}/change-requests`, async ({ request }) => {
 		const payload = (await request.json()) as Partial<ChangeRequest>;
 		const now = new Date().toISOString();
-	const { username } = getActiveAdmin();
-	const created: ChangeRequest = {
-		id: ++changeRequestId,
-		resourceType: payload.resourceType || "UNKNOWN",
-		action: payload.action || "UNKNOWN",
-		resourceId: payload.resourceId,
-		payloadJson: payload.payloadJson,
-		status: "DRAFT",
-		requestedBy: username || "sysadmin",
-		requestedAt: now,
-	};
+		const { username } = getActiveAdmin();
+		const created: ChangeRequest = {
+			id: ++changeRequestId,
+			resourceType: payload.resourceType || "UNKNOWN",
+			action: payload.action || "UNKNOWN",
+			resourceId: payload.resourceId,
+			payloadJson: payload.payloadJson,
+			status: "DRAFT",
+			requestedBy: username || "sysadmin",
+			requestedAt: now,
+		};
 		changeRequests.unshift(created);
 		return json(created);
 	}),
 
 	http.post(`${ADMIN_API}/change-requests/:id/submit`, ({ params }) => {
 		const id = Number(params.id);
-	const item = changeRequests.find((request) => request.id === id);
-	if (!item) {
-		return HttpResponse.json({ status: ResultStatus.ERROR, message: "变更不存在" }, { status: 404 });
-	}
-	item.status = "PENDING";
-	return json(item);
+		const item = changeRequests.find((request) => request.id === id);
+		if (!item) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "变更不存在" }, { status: 404 });
+		}
+		item.status = "PENDING";
+		return json(item);
 	}),
 
 	http.post(`${ADMIN_API}/change-requests/:id/approve`, async ({ params, request }) => {
 		const id = Number(params.id);
-	const item = changeRequests.find((requestItem) => requestItem.id === id);
-	if (!item) {
-		return HttpResponse.json({ status: ResultStatus.ERROR, message: "变更不存在" }, { status: 404 });
-	}
-	const { reason } = (await request.json().catch(() => ({}))) as { reason?: string };
-	item.status = "APPROVED";
-	item.decidedBy = getActiveAdmin().username || "sysadmin";
-	item.decidedAt = new Date().toISOString();
-	item.reason = reason;
-	return json(item);
+		const item = changeRequests.find((requestItem) => requestItem.id === id);
+		if (!item) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "变更不存在" }, { status: 404 });
+		}
+		const { reason } = (await request.json().catch(() => ({}))) as { reason?: string };
+		item.status = "APPROVED";
+		item.decidedBy = getActiveAdmin().username || "sysadmin";
+		item.decidedAt = new Date().toISOString();
+		item.reason = reason;
+		return json(item);
 	}),
 
 	http.post(`${ADMIN_API}/change-requests/:id/reject`, async ({ params, request }) => {
 		const id = Number(params.id);
-	const item = changeRequests.find((requestItem) => requestItem.id === id);
-	if (!item) {
-		return HttpResponse.json({ status: ResultStatus.ERROR, message: "变更不存在" }, { status: 404 });
-	}
-	const { reason } = (await request.json().catch(() => ({}))) as { reason?: string };
-	item.status = "REJECTED";
-	item.decidedBy = getActiveAdmin().username || "sysadmin";
-	item.decidedAt = new Date().toISOString();
-	item.reason = reason || "";
-	return json(item);
+		const item = changeRequests.find((requestItem) => requestItem.id === id);
+		if (!item) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "变更不存在" }, { status: 404 });
+		}
+		const { reason } = (await request.json().catch(() => ({}))) as { reason?: string };
+		item.status = "REJECTED";
+		item.decidedBy = getActiveAdmin().username || "sysadmin";
+		item.decidedAt = new Date().toISOString();
+		item.reason = reason || "";
+		return json(item);
 	}),
 
 	http.get(`${ADMIN_API}/audit`, ({ request }) => {
@@ -330,15 +452,15 @@ export const adminHandlers = [
 
 	http.post(`${ADMIN_API}/system/config`, async ({ request }) => {
 		const config = (await request.json()) as SystemConfigItem;
-	const draft: ChangeRequest = {
-		id: ++changeRequestId,
-		resourceType: "CONFIG",
-		action: "CONFIG_SET",
-		payloadJson: JSON.stringify(config),
-		status: "PENDING",
-		requestedBy: getActiveAdmin().username || "sysadmin",
-		requestedAt: new Date().toISOString(),
-	};
+		const draft: ChangeRequest = {
+			id: ++changeRequestId,
+			resourceType: "CONFIG",
+			action: "CONFIG_SET",
+			payloadJson: JSON.stringify(config),
+			status: "PENDING",
+			requestedBy: getActiveAdmin().username || "sysadmin",
+			requestedAt: new Date().toISOString(),
+		};
 		changeRequests.unshift(draft);
 		return json(draft);
 	}),
@@ -347,47 +469,117 @@ export const adminHandlers = [
 
 	http.post(`${ADMIN_API}/portal/menus`, async ({ request }) => {
 		const body = (await request.json()) as PortalMenuItem;
-	const draft: ChangeRequest = {
-		id: ++changeRequestId,
-		resourceType: "PORTAL_MENU",
-		action: "CREATE",
-		payloadJson: JSON.stringify(body),
-		status: "PENDING",
-		requestedBy: getActiveAdmin().username || "sysadmin",
-		requestedAt: new Date().toISOString(),
-	};
+		const draft: ChangeRequest = {
+			id: ++changeRequestId,
+			resourceType: "PORTAL_MENU",
+			action: "CREATE",
+			payloadJson: JSON.stringify(body),
+			status: "PENDING",
+			requestedBy: getActiveAdmin().username || "sysadmin",
+			requestedAt: new Date().toISOString(),
+		};
 		changeRequests.unshift(draft);
 		return json(draft);
 	}),
 
 	http.put(`${ADMIN_API}/portal/menus/:id`, async ({ request, params }) => {
 		const body = (await request.json()) as PortalMenuItem;
-	const draft: ChangeRequest = {
-		id: ++changeRequestId,
-		resourceType: "PORTAL_MENU",
-		action: "UPDATE",
-		resourceId: String(params.id),
-		payloadJson: JSON.stringify(body),
-		status: "PENDING",
-		requestedBy: getActiveAdmin().username || "sysadmin",
-		requestedAt: new Date().toISOString(),
-	};
+		const draft: ChangeRequest = {
+			id: ++changeRequestId,
+			resourceType: "PORTAL_MENU",
+			action: "UPDATE",
+			resourceId: String(params.id),
+			payloadJson: JSON.stringify(body),
+			status: "PENDING",
+			requestedBy: getActiveAdmin().username || "sysadmin",
+			requestedAt: new Date().toISOString(),
+		};
 		changeRequests.unshift(draft);
 		return json(draft);
 	}),
 
 	http.delete(`${ADMIN_API}/portal/menus/:id`, ({ params }) => {
-	const draft: ChangeRequest = {
-		id: ++changeRequestId,
-		resourceType: "PORTAL_MENU",
-		action: "DELETE",
-		resourceId: String(params.id),
-		status: "PENDING",
-		requestedBy: getActiveAdmin().username || "sysadmin",
-		requestedAt: new Date().toISOString(),
-	};
+		const draft: ChangeRequest = {
+			id: ++changeRequestId,
+			resourceType: "PORTAL_MENU",
+			action: "DELETE",
+			resourceId: String(params.id),
+			status: "PENDING",
+			requestedBy: getActiveAdmin().username || "sysadmin",
+			requestedAt: new Date().toISOString(),
+		};
 		changeRequests.unshift(draft);
 		return json(draft);
+	}),
+
+	http.post(`${ADMIN_API}/orgs`, async ({ request }) => {
+		const payload = (await request.json()) as OrganizationPayload;
+		const name = payload.name?.trim();
+		if (!name) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "部门名称不能为空" }, { status: 400 });
+		}
+		if (!payload.dataLevel) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "请选择部门数据密级" }, { status: 400 });
+		}
+		const parentId = payload.parentId ?? null;
+		if (parentId !== null && !findOrganization(organizations, parentId)) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "父级部门不存在" }, { status: 400 });
+		}
+		const newOrg: OrganizationNode = {
+			id: ++organizationId,
+			name,
+			dataLevel: payload.dataLevel,
+			sensitivity: payload.dataLevel,
+			parentId,
+			contact: payload.contact?.trim() || undefined,
+			phone: payload.phone?.trim() || undefined,
+			description: payload.description?.trim() || undefined,
+			children: [],
+		};
+		if (!insertOrganization(organizations, parentId, newOrg)) {
+			organizationId -= 1;
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "无法创建部门，请重试" }, { status: 400 });
+		}
+		return json(newOrg);
+	}),
+
+	http.put(`${ADMIN_API}/orgs/:id`, async ({ params, request }) => {
+		const id = Number(params.id);
+		if (Number.isNaN(id)) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "部门ID不合法" }, { status: 400 });
+		}
+		const payload = (await request.json()) as OrganizationPayload;
+		const name = payload.name?.trim();
+		if (!name) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "部门名称不能为空" }, { status: 400 });
+		}
+		if (!payload.dataLevel) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "请选择部门数据密级" }, { status: 400 });
+		}
+		const updated = updateOrganizationNode(organizations, id, {
+			name,
+			dataLevel: payload.dataLevel,
+			sensitivity: payload.dataLevel,
+			contact: payload.contact?.trim() || undefined,
+			phone: payload.phone?.trim() || undefined,
+			description: payload.description?.trim() || undefined,
+		});
+		if (!updated) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "部门不存在" }, { status: 404 });
+		}
+		return json(updated);
+	}),
+
+	http.delete(`${ADMIN_API}/orgs/:id`, ({ params }) => {
+		const id = Number(params.id);
+		if (Number.isNaN(id)) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "部门ID不合法" }, { status: 400 });
+		}
+		const removed = deleteOrganizationNode(organizations, id);
+		if (!removed) {
+			return HttpResponse.json({ status: ResultStatus.ERROR, message: "部门不存在" }, { status: 404 });
+		}
+		return json({ id });
 	}),
 
 	http.get(`${ADMIN_API}/orgs`, () => json(organizations)),
@@ -402,14 +594,7 @@ export const adminHandlers = [
 function buildCsv(events: AuditEvent[]) {
 	const header = "id,timestamp,actor,action,resource,outcome";
 	const rows = events.map((event) =>
-		[
-			event.id,
-			event.timestamp,
-			event.actor ?? "",
-			event.action ?? "",
-			event.resource ?? "",
-			event.outcome ?? "",
-		]
+		[event.id, event.timestamp, event.actor ?? "", event.action ?? "", event.resource ?? "", event.outcome ?? ""]
 			.map((value) => `"${String(value).replaceAll('"', '""')}"`)
 			.join(","),
 	);

--- a/src/admin/api/adminApi.ts
+++ b/src/admin/api/adminApi.ts
@@ -1,15 +1,16 @@
-import apiClient from "@/api/apiClient";
 import type {
+	AdminRoleDetail,
+	AdminUser,
 	AdminWhoami,
 	AuditEvent,
-	PortalMenuItem,
-	SystemConfigItem,
 	ChangeRequest,
 	OrganizationNode,
-	AdminUser,
-	AdminRoleDetail,
+	OrganizationPayload,
 	PermissionCatalogSection,
+	PortalMenuItem,
+	SystemConfigItem,
 } from "@/admin/types";
+import apiClient from "@/api/apiClient";
 
 export interface ChangeRequestQuery {
 	status?: string;
@@ -98,6 +99,23 @@ export const adminApi = {
 	getOrganizations: () =>
 		apiClient.get<OrganizationNode[]>({
 			url: "/admin/orgs",
+		}),
+
+	createOrganization: (payload: OrganizationPayload) =>
+		apiClient.post<OrganizationNode>({
+			url: "/admin/orgs",
+			data: payload,
+		}),
+
+	updateOrganization: (id: number, payload: OrganizationPayload) =>
+		apiClient.put<OrganizationNode>({
+			url: `/admin/orgs/${id}`,
+			data: payload,
+		}),
+
+	deleteOrganization: (id: number) =>
+		apiClient.delete<void>({
+			url: `/admin/orgs/${id}`,
 		}),
 
 	getAdminUsers: () =>

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -52,18 +52,33 @@ export interface PortalMenuItem {
 	children?: PortalMenuItem[];
 }
 
+export type OrgDataLevel = "DATA_PUBLIC" | "DATA_INTERNAL" | "DATA_SECRET" | "DATA_TOP_SECRET";
+
 export interface OrganizationNode {
 	id: number;
 	name: string;
-	code: string;
+	dataLevel: OrgDataLevel;
 	parentId?: number | null;
+	contact?: string;
+	phone?: string;
+	description?: string;
+	// legacy fields kept optional for compatibility with draft flows
+	code?: string;
 	leader?: string;
 	memberCount?: number;
-	description?: string;
 	securityDomains?: string[];
 	sensitivity?: string;
 	level?: number;
 	children?: OrganizationNode[];
+}
+
+export interface OrganizationPayload {
+	name: string;
+	dataLevel: OrgDataLevel;
+	parentId?: number | null;
+	contact?: string;
+	phone?: string;
+	description?: string;
 }
 
 export interface AdminUser {

--- a/src/admin/views/org-management.tsx
+++ b/src/admin/views/org-management.tsx
@@ -1,30 +1,99 @@
-import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { type Resolver, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
 import { adminApi } from "@/admin/api/adminApi";
-import type { OrganizationNode } from "@/admin/types";
 import { ChangeRequestForm } from "@/admin/components/change-request-form";
 import { useAdminLocale } from "@/admin/lib/locale";
+import type { OrganizationNode, OrganizationPayload, OrgDataLevel } from "@/admin/types";
 import { Badge } from "@/ui/badge";
+import { Button } from "@/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/ui/form";
 import { Input } from "@/ui/input";
 import { ScrollArea } from "@/ui/scroll-area";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/select";
 import { Text } from "@/ui/typography";
 
+const DATA_LEVEL_VALUES = ["DATA_PUBLIC", "DATA_INTERNAL", "DATA_SECRET", "DATA_TOP_SECRET"] as const;
+const DATA_LEVEL_OPTIONS: { value: OrgDataLevel; label: string }[] = [
+	{ value: "DATA_PUBLIC", label: "公开" },
+	{ value: "DATA_INTERNAL", label: "内部" },
+	{ value: "DATA_SECRET", label: "秘密" },
+	{ value: "DATA_TOP_SECRET", label: "机密" },
+];
+
+const LEGACY_LEVEL_MAP: Record<string, OrgDataLevel> = {
+	TOP_SECRET: "DATA_TOP_SECRET",
+	SECRET: "DATA_SECRET",
+	NORMAL: "DATA_INTERNAL",
+	UNKNOWN: "DATA_INTERNAL",
+};
+
+const orgFormSchema = z.object({
+	name: z.string().trim().min(1, "请输入部门名称"),
+	dataLevel: z.enum(DATA_LEVEL_VALUES, { required_error: "请选择数据密级" }),
+	contact: z.preprocess((value) => {
+		if (typeof value === "string") {
+			const trimmed = value.trim();
+			return trimmed.length === 0 ? undefined : trimmed;
+		}
+		return value;
+	}, z.string().max(32, "联系人姓名过长").optional()),
+	phone: z.preprocess(
+		(value) => {
+			if (typeof value === "string") {
+				const trimmed = value.trim();
+				return trimmed.length === 0 ? undefined : trimmed;
+			}
+			return value;
+		},
+		z
+			.string()
+			.regex(/^[0-9+\-()\s]{5,20}$/, "请输入有效的联系电话")
+			.optional(),
+	),
+});
+
+type OrgFormValues = z.infer<typeof orgFormSchema>;
+type FlattenedOrganization = OrganizationNode & { level: number; path: string[] };
+
+interface FormState {
+	open: boolean;
+	mode: "create" | "edit";
+	parentId: number | null;
+	target: FlattenedOrganization | null;
+}
+
 export default function OrgManagementView() {
+	const queryClient = useQueryClient();
 	const { data: tree = [], isLoading } = useQuery({
 		queryKey: ["admin", "organizations"],
 		queryFn: adminApi.getOrganizations,
 	});
 	const [search, setSearch] = useState("");
 	const [selectedId, setSelectedId] = useState<number | null>(null);
+	const [formState, setFormState] = useState<FormState>({
+		open: false,
+		mode: "create",
+		parentId: null,
+		target: null,
+	});
+	const [deleteState, setDeleteState] = useState<{ open: boolean; target: FlattenedOrganization | null }>({
+		open: false,
+		target: null,
+	});
 	const { translateSensitivity } = useAdminLocale();
 
 	const flattened = useMemo(() => flattenTree(tree), [tree]);
 	const filteredTree = useMemo(() => {
 		if (!search.trim()) return tree;
 		const keyword = search.trim().toLowerCase();
-		return filterTree(tree, keyword);
-	}, [search, tree]);
+		return filterTree(tree, keyword, translateSensitivity);
+	}, [search, tree, translateSensitivity]);
 
 	const selected = useMemo(() => {
 		if (!selectedId) return null;
@@ -33,25 +102,143 @@ export default function OrgManagementView() {
 
 	const stats = useMemo(() => {
 		const totalOrg = flattened.length;
-		const totalMembers = flattened.reduce((sum, item) => sum + (item.memberCount || 0), 0);
-		const sensitiveOrgs = flattened.filter((item) => item.sensitivity === "SECRET" || item.sensitivity === "TOP_SECRET").length;
-		return { totalOrg, totalMembers, sensitiveOrgs };
+		const sensitiveOrgs = flattened.filter((item) => {
+			const level = normalizeDataLevel(item.dataLevel ?? item.sensitivity);
+			return level === "DATA_SECRET" || level === "DATA_TOP_SECRET";
+		}).length;
+		const topSecret = flattened.filter(
+			(item) => normalizeDataLevel(item.dataLevel ?? item.sensitivity) === "DATA_TOP_SECRET",
+		).length;
+		return { totalOrg, sensitiveOrgs, topSecret };
 	}, [flattened]);
+
+	const createMutation = useMutation({
+		mutationFn: (payload: OrganizationPayload) => adminApi.createOrganization(payload),
+	});
+	const updateMutation = useMutation({
+		mutationFn: ({ id, payload }: { id: number; payload: OrganizationPayload }) =>
+			adminApi.updateOrganization(id, payload),
+	});
+	const deleteMutation = useMutation({
+		mutationFn: (id: number) => adminApi.deleteOrganization(id),
+	});
+
+	const formLoading = createMutation.isPending || updateMutation.isPending;
+
+	const openCreateRoot = () => {
+		setFormState({ open: true, mode: "create", parentId: null, target: null });
+	};
+
+	const openCreateChild = () => {
+		if (!selected) return;
+		setFormState({ open: true, mode: "create", parentId: selected.id, target: selected });
+	};
+
+	const openEdit = () => {
+		if (!selected) return;
+		setFormState({ open: true, mode: "edit", parentId: selected.parentId ?? null, target: selected });
+	};
+
+	const openDelete = () => {
+		if (!selected) return;
+		setDeleteState({ open: true, target: selected });
+	};
+
+	const closeForm = () => setFormState({ open: false, mode: "create", parentId: null, target: null });
+	const closeDelete = () => setDeleteState({ open: false, target: null });
+
+	const handleSubmitForm = async (values: OrgFormValues) => {
+		if (formState.mode === "create") {
+			const payload: OrganizationPayload = {
+				...values,
+				parentId: formState.parentId ?? null,
+			};
+			try {
+				const created = await createMutation.mutateAsync(payload);
+				toast.success("部门新增成功");
+				closeForm();
+				setSelectedId(created.id);
+				await queryClient.invalidateQueries({ queryKey: ["admin", "organizations"] });
+			} catch (error) {
+				console.error(error);
+			}
+			return;
+		}
+
+		if (formState.mode === "edit" && formState.target) {
+			const payload: OrganizationPayload = { ...values };
+			try {
+				await updateMutation.mutateAsync({ id: formState.target.id, payload });
+				toast.success("部门信息已更新");
+				closeForm();
+				await queryClient.invalidateQueries({ queryKey: ["admin", "organizations"] });
+			} catch (error) {
+				console.error(error);
+			}
+		}
+	};
+
+	const handleConfirmDelete = async () => {
+		const target = deleteState.target;
+		if (!target) return;
+		try {
+			await deleteMutation.mutateAsync(target.id);
+			toast.success("部门已删除");
+			closeDelete();
+			await queryClient.invalidateQueries({ queryKey: ["admin", "organizations"] });
+			setSelectedId((current) => {
+				if (current === target.id) {
+					return target.parentId ?? null;
+				}
+				return current;
+			});
+		} catch (error) {
+			console.error(error);
+		}
+	};
+
+	const editingNode = formState.mode === "edit" ? formState.target : null;
+	const parentLabel =
+		formState.mode === "create"
+			? formState.parentId
+				? (formState.target?.path.join(" / ") ?? "")
+				: "无（一级部门）"
+			: editingNode
+				? editingNode.path.slice(0, -1).join(" / ") || "无（一级部门）"
+				: undefined;
+	const initialValues: OrgFormValues = editingNode
+		? {
+				name: editingNode.name,
+				dataLevel: normalizeDataLevel(editingNode.dataLevel ?? editingNode.sensitivity),
+				contact: editingNode.contact ?? "",
+				phone: editingNode.phone ?? "",
+			}
+		: {
+				name: "",
+				dataLevel: normalizeDataLevel(formState.target?.dataLevel ?? formState.target?.sensitivity),
+				contact: "",
+				phone: "",
+			};
 
 	return (
 		<div className="grid gap-6 xl:grid-cols-[minmax(0,0.6fr)_minmax(0,1fr)]">
 			<Card>
 				<CardHeader className="space-y-3">
-					<CardTitle>组织结构</CardTitle>
+					<div className="flex items-center justify-between gap-3">
+						<CardTitle>组织结构</CardTitle>
+						<Button size="sm" onClick={openCreateRoot}>
+							新增部门
+						</Button>
+					</div>
 					<Input
-						placeholder="搜索组织 / 负责人"
+						placeholder="搜索部门 / 联系人 / 数据密级"
 						value={search}
 						onChange={(event) => setSearch(event.target.value)}
 					/>
 					<div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
 						<span>组织数：{stats.totalOrg}</span>
-						<span>成员总数：{stats.totalMembers}</span>
-						<span>涉敏组织：{stats.sensitiveOrgs}</span>
+						<span>涉敏部门：{stats.sensitiveOrgs}</span>
+						<span>机密部门：{stats.topSecret}</span>
 					</div>
 				</CardHeader>
 				<CardContent className="h-[560px] p-0">
@@ -65,7 +252,12 @@ export default function OrgManagementView() {
 								{filteredTree.length === 0 ? (
 									<Text variant="body3">未找到匹配的组织。</Text>
 								) : (
-									<OrganizationTree tree={filteredTree} onSelect={setSelectedId} selectedId={selectedId} />
+									<OrganizationTree
+										tree={filteredTree}
+										onSelect={setSelectedId}
+										selectedId={selectedId}
+										translateLevel={translateSensitivity}
+									/>
 								)}
 							</div>
 						</ScrollArea>
@@ -75,26 +267,59 @@ export default function OrgManagementView() {
 
 			<div className="space-y-6">
 				<Card>
-					<CardHeader>
+					<CardHeader className="flex flex-wrap items-center justify-between gap-3">
 						<CardTitle>组织详情</CardTitle>
+						<div className="flex flex-wrap gap-2">
+							<Button variant="outline" size="sm" onClick={openCreateChild} disabled={!selected}>
+								新增下级
+							</Button>
+							<Button variant="outline" size="sm" onClick={openEdit} disabled={!selected}>
+								编辑
+							</Button>
+							<Button
+								variant="ghost"
+								size="sm"
+								className="text-destructive hover:text-destructive"
+								onClick={openDelete}
+								disabled={!selected}
+							>
+								删除
+							</Button>
+						</div>
 					</CardHeader>
-					<CardContent className="space-y-3 text-sm">
+					<CardContent className="space-y-4 text-sm">
 						{selected ? (
 							<>
-								<Text variant="body2" className="font-semibold">
-									{selected.name}
-								</Text>
-								<p className="text-muted-foreground">编码：{selected.code}</p>
-								<p className="text-muted-foreground">负责人：{selected.leader || "--"}</p>
-								<p className="text-muted-foreground">成员数量：{selected.memberCount ?? 0}</p>
-								<p className="text-muted-foreground">数据权限范围：{selected.securityDomains?.join("、") || "--"}</p>
-								<div className="flex flex-wrap gap-2">
-									<Badge variant="outline">层级：{selected.level ?? "--"}</Badge>
-								<Badge variant={selected.sensitivity === "TOP_SECRET" ? "destructive" : "secondary"}>
-									敏感度：{translateSensitivity(selected.sensitivity, selected.sensitivity || "NORMAL")}
-								</Badge>
+								<div className="flex flex-wrap items-center gap-3">
+									<Text variant="body2" className="font-semibold">
+										{selected.name}
+									</Text>
+									<Badge variant={getDataLevelBadgeVariant(selected.dataLevel ?? selected.sensitivity)}>
+										{translateSensitivity(
+											selected.dataLevel ?? selected.sensitivity,
+											getDataLevelFallback(selected.dataLevel ?? selected.sensitivity),
+										)}
+									</Badge>
 								</div>
-								{selected.description ? <p className="text-muted-foreground">{selected.description}</p> : null}
+								<p className="text-muted-foreground">部门ID：{selected.id}</p>
+								<p className="text-muted-foreground">
+									上级部门：{selected.path.slice(0, -1).join(" / ") || "无（一级部门）"}
+								</p>
+								<div className="grid gap-3 sm:grid-cols-2">
+									<div>
+										<p className="text-xs text-muted-foreground">联系人</p>
+										<p className="text-sm font-medium text-foreground">{selected.contact ?? "--"}</p>
+									</div>
+									<div>
+										<p className="text-xs text-muted-foreground">联系电话</p>
+										<p className="text-sm font-medium text-foreground">{selected.phone ?? "--"}</p>
+									</div>
+								</div>
+								{selected.description ? (
+									<div className="rounded-md border border-dashed border-muted/60 bg-muted/30 p-3 text-sm text-muted-foreground">
+										{selected.description}
+									</div>
+								) : null}
 							</>
 						) : (
 							<Text variant="body3" className="text-muted-foreground">
@@ -113,11 +338,32 @@ export default function OrgManagementView() {
 					</CardContent>
 				</Card>
 			</div>
+
+			<OrganizationFormDialog
+				open={formState.open}
+				mode={formState.mode}
+				loading={formLoading}
+				initialValues={initialValues}
+				parentLabel={parentLabel}
+				onSubmit={handleSubmitForm}
+				onClose={closeForm}
+			/>
+
+			<ConfirmDeleteDialog
+				open={deleteState.open}
+				name={deleteState.target?.name}
+				loading={deleteMutation.isPending}
+				onCancel={closeDelete}
+				onConfirm={handleConfirmDelete}
+			/>
 		</div>
 	);
 }
-
-function flattenTree(tree: OrganizationNode[], level = 1, parentPath: string[] = []): (OrganizationNode & { level: number; path: string[] })[] {
+function flattenTree(
+	tree: OrganizationNode[],
+	level = 1,
+	parentPath: string[] = [],
+): (OrganizationNode & { level: number; path: string[] })[] {
 	const result: (OrganizationNode & { level: number; path: string[] })[] = [];
 	for (const node of tree) {
 		const path = [...parentPath, node.name];
@@ -129,21 +375,57 @@ function flattenTree(tree: OrganizationNode[], level = 1, parentPath: string[] =
 	return result;
 }
 
-function filterTree(tree: OrganizationNode[], keyword: string): OrganizationNode[] {
+function filterTree(
+	tree: OrganizationNode[],
+	keyword: string,
+	translateLevel: (value?: string | null, fallback?: string) => string,
+): OrganizationNode[] {
+	const includesKeyword = (value?: string | null) => (value ? value.toLowerCase().includes(keyword) : false);
 	const matchNode = (node: OrganizationNode): OrganizationNode | null => {
+		const fallback = getDataLevelFallback(node.dataLevel ?? node.sensitivity);
+		const translated = translateLevel(node.dataLevel ?? node.sensitivity, fallback);
 		const hit =
-			node.name.toLowerCase().includes(keyword) ||
-			node.code?.toLowerCase().includes(keyword) ||
-			node.leader?.toLowerCase().includes(keyword);
+			includesKeyword(node.name) ||
+			includesKeyword(node.contact) ||
+			includesKeyword(node.phone) ||
+			includesKeyword(node.dataLevel ?? node.sensitivity) ||
+			includesKeyword(fallback) ||
+			includesKeyword(translated);
 		const children = node.children?.map(matchNode).filter((item): item is OrganizationNode => Boolean(item)) ?? [];
 		if (hit || children.length > 0) {
 			return { ...node, children };
 		}
 		return null;
 	};
-	return tree
-		.map(matchNode)
-		.filter((item): item is OrganizationNode => Boolean(item));
+	return tree.map(matchNode).filter((item): item is OrganizationNode => Boolean(item));
+}
+
+function getDataLevelFallback(level?: string | null) {
+	const normalized = normalizeDataLevel(level);
+	const option = DATA_LEVEL_OPTIONS.find((item) => item.value === normalized);
+	return option?.label ?? normalized;
+}
+
+function normalizeDataLevel(level?: string | null): OrgDataLevel {
+	if (!level) return "DATA_PUBLIC";
+	if (DATA_LEVEL_VALUES.includes(level as OrgDataLevel)) {
+		return level as OrgDataLevel;
+	}
+	return LEGACY_LEVEL_MAP[level] ?? "DATA_PUBLIC";
+}
+
+function getDataLevelBadgeVariant(level?: string | null) {
+	const normalized = normalizeDataLevel(level);
+	switch (normalized) {
+		case "DATA_TOP_SECRET":
+			return "destructive" as const;
+		case "DATA_SECRET":
+			return "secondary" as const;
+		case "DATA_INTERNAL":
+			return "default" as const;
+		default:
+			return "outline" as const;
+	}
 }
 
 interface TreeProps {
@@ -151,9 +433,10 @@ interface TreeProps {
 	onSelect: (id: number) => void;
 	selectedId: number | null;
 	depth?: number;
+	translateLevel: (value?: string | null, fallback?: string) => string;
 }
 
-function OrganizationTree({ tree, onSelect, selectedId, depth = 0 }: TreeProps) {
+function OrganizationTree({ tree, onSelect, selectedId, depth = 0, translateLevel }: TreeProps) {
 	return (
 		<ul className="space-y-1">
 			{tree.map((node) => {
@@ -163,24 +446,219 @@ function OrganizationTree({ tree, onSelect, selectedId, depth = 0 }: TreeProps) 
 						<button
 							type="button"
 							onClick={() => onSelect(node.id)}
-							className={`flex w-full items-center justify-between rounded-md px-2 py-1 text-left text-sm transition ${
+							className={`flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition ${
 								isActive ? "bg-primary text-primary-foreground" : "hover:bg-muted"
 							}`}
 							style={{ paddingLeft: depth * 16 + 8 }}
 						>
-							<span className="flex-1">{node.name}</span>
-							<span className="text-xs text-muted-foreground">
-								{node.memberCount ?? 0}
-							</span>
+							<div className="flex min-w-0 flex-1 flex-col">
+								<span className="truncate font-medium">{node.name}</span>
+								{node.contact ? (
+									<span
+										className={`truncate text-xs ${isActive ? "text-primary-foreground/80" : "text-muted-foreground"}`}
+									>
+										{node.contact}
+									</span>
+								) : null}
+							</div>
+							<Badge variant={getDataLevelBadgeVariant(node.dataLevel ?? node.sensitivity)} className="ml-2">
+								{translateLevel(
+									node.dataLevel ?? node.sensitivity,
+									getDataLevelFallback(node.dataLevel ?? node.sensitivity),
+								)}
+							</Badge>
 						</button>
 						{node.children?.length ? (
 							<div className="ml-2 border-l border-border pl-2">
-								<OrganizationTree tree={node.children} onSelect={onSelect} selectedId={selectedId} depth={depth + 1} />
+								<OrganizationTree
+									tree={node.children}
+									onSelect={onSelect}
+									selectedId={selectedId}
+									depth={depth + 1}
+									translateLevel={translateLevel}
+								/>
 							</div>
 						) : null}
 					</li>
 				);
 			})}
 		</ul>
+	);
+}
+
+interface OrganizationFormDialogProps {
+	open: boolean;
+	mode: "create" | "edit";
+	loading?: boolean;
+	initialValues: OrgFormValues;
+	parentLabel?: string;
+	onSubmit: (values: OrgFormValues) => Promise<void>;
+	onClose: () => void;
+}
+
+function OrganizationFormDialog({
+	open,
+	mode,
+	loading,
+	initialValues,
+	parentLabel,
+	onSubmit,
+	onClose,
+}: OrganizationFormDialogProps) {
+	const form = useForm<OrgFormValues, any, OrgFormValues>({
+		resolver: zodResolver(orgFormSchema) as Resolver<OrgFormValues>,
+		defaultValues: initialValues,
+	});
+
+	useEffect(() => {
+		if (open) {
+			form.reset(initialValues);
+		}
+	}, [form, initialValues, open]);
+
+	const handleOpenChange = (value: boolean) => {
+		if (!value && !loading) {
+			onClose();
+		}
+	};
+
+	const handleSubmit = form.handleSubmit(async (values: OrgFormValues) => {
+		await onSubmit(values);
+	});
+
+	const title = mode === "create" ? "新增部门" : "编辑部门";
+	const submitText = mode === "create" ? "新增" : "保存";
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="min-w-[420px] max-w-[520px]">
+				<DialogHeader>
+					<DialogTitle>{title}</DialogTitle>
+					<DialogDescription>请填写部门基础信息并确认数据密级。</DialogDescription>
+				</DialogHeader>
+				{parentLabel ? (
+					<div className="rounded-md border border-dashed border-muted/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+						<span className="font-medium text-foreground">上级部门：</span>
+						{parentLabel}
+					</div>
+				) : null}
+				<Form {...form}>
+					<form onSubmit={handleSubmit} className="space-y-4">
+						<FormField
+							control={form.control}
+							name="name"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>部门名称</FormLabel>
+									<FormControl>
+										<Input placeholder="请输入部门名称" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="dataLevel"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>数据密级</FormLabel>
+									<FormControl>
+										<Select onValueChange={field.onChange} value={field.value}>
+											<SelectTrigger className="w-full justify-between">
+												<SelectValue placeholder="请选择数据密级" />
+											</SelectTrigger>
+											<SelectContent>
+												{DATA_LEVEL_OPTIONS.map((option) => (
+													<SelectItem key={option.value} value={option.value}>
+														{option.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<div className="grid gap-4 sm:grid-cols-2">
+							<FormField
+								control={form.control}
+								name="contact"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>联系人</FormLabel>
+										<FormControl>
+											<Input placeholder="请输入联系人" {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="phone"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>联系电话</FormLabel>
+										<FormControl>
+											<Input placeholder="请输入联系电话" {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+						<DialogFooter>
+							<Button type="button" variant="outline" onClick={onClose} disabled={loading}>
+								取消
+							</Button>
+							<Button type="submit" disabled={loading}>
+								{loading ? `${submitText}中...` : submitText}
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+interface ConfirmDeleteDialogProps {
+	open: boolean;
+	name?: string;
+	loading?: boolean;
+	onCancel: () => void;
+	onConfirm: () => void;
+}
+
+function ConfirmDeleteDialog({ open, name, loading, onCancel, onConfirm }: ConfirmDeleteDialogProps) {
+	const handleOpenChange = (value: boolean) => {
+		if (!value && !loading) {
+			onCancel();
+		}
+	};
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="min-w-[420px] max-w-[480px]">
+				<DialogHeader>
+					<DialogTitle>确认删除部门</DialogTitle>
+					<DialogDescription>删除后该部门及其子部门将无法恢复，请谨慎操作。</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-2 py-2 text-sm">
+					<p>
+						即将删除：<span className="font-medium text-foreground">{name ?? "未命名部门"}</span>
+					</p>
+				</div>
+				<DialogFooter>
+					<Button variant="outline" onClick={onCancel} disabled={loading}>
+						取消
+					</Button>
+					<Button variant="destructive" onClick={onConfirm} disabled={loading}>
+						{loading ? "删除中..." : "确认删除"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
 	);
 }

--- a/src/locales/lang/zh_CN/sys.json
+++ b/src/locales/lang/zh_CN/sys.json
@@ -233,6 +233,10 @@
 				"DATA_ANALYST": "数据分析师"
 			},
 			"sensitivity": {
+				"DATA_PUBLIC": "公开",
+				"DATA_INTERNAL": "内部",
+				"DATA_SECRET": "秘密",
+				"DATA_TOP_SECRET": "机密",
 				"TOP_SECRET": "绝密",
 				"SECRET": "机密",
 				"NORMAL": "普通",


### PR DESCRIPTION
## Summary
- extend organization typings and admin API to carry data-level, contact and phone metadata
- rebuild the organization management view with create/edit/delete dialogs, validation and improved tree browsing
- update the mock admin handlers and locales to support the new organization fields and CRUD endpoints

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d3764144c4832a9668c5b5fca9d465