### PR TITLE
fix: repair user management screens

### DIFF
--- a/src/pages/management/system/user/index.tsx
+++ b/src/pages/management/system/user/index.tsx
@@ -5,7 +5,6 @@ import { toast } from "sonner";
 import type { KeycloakUser, PaginationParams, UserProfileConfig, UserTableRow } from "#/keycloak";
 import { KeycloakUserProfileService, KeycloakUserService } from "@/api/services/keycloakService";
 import type { CustomUserAttributeKey } from "@/constants/user";
-import { CUSTOM_USER_ATTRIBUTE_KEYS } from "@/constants/user";
 import { Icon } from "@/components/icon";
 import { PERSON_SECURITY_LEVELS } from "@/constants/governance";
 import { usePathname, useRouter } from "@/routes/hooks";
@@ -30,16 +29,6 @@ const RESERVED_PROFILE_ATTRIBUTE_NAMES = new Set([
 	"personnel_security_level",
 	"person_level",
 	"data_levels",
-]);
-
-const RESERVED_PROFILE_ATTRIBUTES = new Set<string>([
-	"username",
-	"email",
-	"firstName",
-	"lastName",
-	"locale",
-	"fullname",
-	...CUSTOM_USER_ATTRIBUTE_KEYS,
 ]);
 
 const getSingleAttributeValue = (attributes: Record<string, string[]> | undefined, key: CustomUserAttributeKey) => {
@@ -172,11 +161,6 @@ export default function UserPage() {
 			),
 		},
 		{
-			title: "人员密级",
-			dataIndex: ["attributes", "personnel_security_level"],
-			width: 140,
-			render: (_: string[] | undefined, record) => {
-				const value = getSingleAttributeValue(record.attributes, "personnel_security_level");
 			title: "姓名",
 			dataIndex: "firstName",
 			width: 160,
@@ -190,9 +174,8 @@ export default function UserPage() {
 			dataIndex: ["attributes", "department"],
 			width: 180,
 			render: (_: string[] | undefined, record) => {
-				const value = getSingleAttributeValue(record.attributes, "department");
-				const department = record.attributes?.department?.[0]?.trim();
-				return department && department.length > 0 ? department : "-";
+				const department = getSingleAttributeValue(record.attributes, "department").trim();
+				return department.length > 0 ? department : "-";
 			},
 		},
 		{
@@ -200,10 +183,8 @@ export default function UserPage() {
 			dataIndex: ["attributes", "position"],
 			width: 180,
 			render: (_: string[] | undefined, record) => {
-				const value = getSingleAttributeValue(record.attributes, "position");
-				return value || "-";
-				const position = record.attributes?.position?.[0]?.trim();
-				return position && position.length > 0 ? position : "-";
+				const position = getSingleAttributeValue(record.attributes, "position").trim();
+				return position.length > 0 ? position : "-";
 			},
 		},
 		{
@@ -211,8 +192,9 @@ export default function UserPage() {
 			dataIndex: ["attributes", "personnel_security_level"],
 			width: 150,
 			render: (_: string[] | undefined, record) => {
-				const levelValue =
-					record.attributes?.personnel_security_level?.[0] || record.attributes?.person_security_level?.[0];
+				const primaryLevel = getSingleAttributeValue(record.attributes, "personnel_security_level").trim();
+				const legacyLevel = record.attributes?.person_security_level?.[0]?.trim();
+				const levelValue = primaryLevel || legacyLevel || "";
 				if (!levelValue) return "-";
 				const label = personLevelLabelMap.get(levelValue) ?? levelValue;
 				return label !== levelValue ? `${label}（${levelValue}）` : label;

--- a/src/pages/management/system/user/user-modal.tsx
+++ b/src/pages/management/system/user/user-modal.tsx
@@ -2,13 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import type { CreateUserRequest, KeycloakRole, KeycloakUser, UpdateUserRequest, UserProfileConfig } from "#/keycloak";
 import { KeycloakRoleService, KeycloakUserProfileService, KeycloakUserService } from "@/api/services/keycloakService";
-import type { CustomUserAttributeKey } from "@/constants/user";
-import {
-	CUSTOM_USER_ATTRIBUTE_KEY_SET,
-	DEPARTMENT_SUGGESTIONS,
-	PERSONNEL_SECURITY_LEVEL_OPTIONS,
-	POSITION_SUGGESTIONS,
-} from "@/constants/user";
+import { DEPARTMENT_SUGGESTIONS, POSITION_SUGGESTIONS } from "@/constants/user";
 import { Icon } from "@/components/icon";
 import { Alert, AlertDescription } from "@/ui/alert";
 import { Badge } from "@/ui/badge";
@@ -28,7 +22,6 @@ import {
 	isDataRole,
 	isGovernanceRole,
 } from "@/constants/governance";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/select";
 
 const RESERVED_PROFILE_ATTRIBUTE_NAMES = [
 	"username",
@@ -57,8 +50,6 @@ interface FormData {
 	username: string;
 	fullName: string;
 	email: string;
-	personnelSecurityLevel: string;
-	department: string;
 	enabled: boolean;
 	emailVerified: boolean;
 	attributes: Record<string, string[]>;
@@ -79,9 +70,6 @@ const createEmptyFormData = (): FormData => ({
 	username: "",
 	fullName: "",
 	email: "",
-	personnelSecurityLevel: "",
-	department: "",
-	position: "",
 	enabled: true,
 	emailVerified: false,
 	attributes: {},
@@ -93,45 +81,17 @@ const createEmptyFormState = (): FormState => ({
 	roleChanges: [],
 });
 
-const RESERVED_ATTRIBUTE_NAMES = new Set<string>(["username", "email", "firstName", "lastName", "locale", "fullname"]);
-
-CUSTOM_USER_ATTRIBUTE_KEY_SET.forEach((key) => RESERVED_ATTRIBUTE_NAMES.add(key));
-
 export default function UserModal({ open, mode, user, onCancel, onSuccess }: UserModalProps) {
 	const [formData, setFormData] = useState<FormData>(() => createEmptyFormData());
-	const [formData, setFormData] = useState<FormData>({
-		username: "",
-		fullName: "",
-		email: "",
-		enabled: true,
-		emailVerified: false,
-		attributes: {},
-	});
-
-	const [formState, setFormState] = useState<FormState>({
-		originalData: {
-			username: "",
-			fullName: "",
-			email: "",
-			enabled: true,
-			emailVerified: false,
-			attributes: {},
-		},
-		originalRoles: [],
-		roleChanges: [],
-	});
-
+	const [formState, setFormState] = useState<FormState>(() => createEmptyFormState());
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string>("");
 	const [roles, setRoles] = useState<KeycloakRole[]>([]);
 	const [userRoles, setUserRoles] = useState<KeycloakRole[]>([]);
 	const [roleError, setRoleError] = useState<string>("");
 	const [personLevel, setPersonLevel] = useState<string>("NON_SECRET");
-
-	// UserProfile相关状态
 	const [userProfileConfig, setUserProfileConfig] = useState<UserProfileConfig | null>(null);
 	const [profileLoading, setProfileLoading] = useState(false);
-	//const [setProfileError] = useState<string>("");
 
 	const normalizeAttributesForState = useCallback(
 		(attributes: Record<string, string[]> = {}, level?: string): Record<string, string[]> => {
@@ -195,8 +155,9 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 	const updateSingleValueAttribute = (key: string, value: string) => {
 		setFormData((prev) => {
 			const nextAttributes = { ...prev.attributes };
-			if (value.trim()) {
-				nextAttributes[key] = [value];
+			const trimmed = value.trim();
+			if (trimmed) {
+				nextAttributes[key] = [trimmed];
 			} else {
 				delete nextAttributes[key];
 			}
@@ -208,22 +169,40 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 		});
 	};
 
-	// 加载UserProfile配置
+	const handleProfileFieldChange = (attributeName: string, value: string | string[]) => {
+		setFormData((prev) => {
+			const nextAttributes = { ...prev.attributes };
+			const normalizedValues = Array.isArray(value)
+				? value.map((item) => item.trim()).filter((item) => item.length > 0)
+				: typeof value === "string" && value.trim().length > 0
+					? [value.trim()]
+					: [];
+
+			if (normalizedValues.length > 0) {
+				nextAttributes[attributeName] = normalizedValues;
+			} else {
+				delete nextAttributes[attributeName];
+			}
+
+			return {
+				...prev,
+				attributes: nextAttributes,
+			};
+		});
+	};
+
 	const loadUserProfileConfig = useCallback(async () => {
 		setProfileLoading(true);
-		//setProfileError("");
 		try {
 			const config = await KeycloakUserProfileService.getUserProfileConfig();
 			setUserProfileConfig(config);
 		} catch (err) {
 			console.error("Error loading user profile config:", err);
-			//setProfileError("加载用户配置文件失败");
 		} finally {
 			setProfileLoading(false);
 		}
 	}, []);
 
-	// 加载所有角色
 	const loadRoles = useCallback(async () => {
 		try {
 			const rolesData = await KeycloakRoleService.getAllRealmRoles();
@@ -246,27 +225,23 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 		}
 	}, []);
 
-	// 初始化表单数据
-	useEffect(() => {
-		if (mode === "edit" && user) {
-			const filteredAttributes: Record<string, string[]> = {};
-			if (user.attributes) {
-				Object.entries(user.attributes).forEach(([key, value]) => {
-					if (!CUSTOM_USER_ATTRIBUTE_KEY_SET.has(key)) {
-						filteredAttributes[key] = value;
-					}
-				});
-			}
+	const handlePersonLevelChange = useCallback(
+		(level: string) => {
+			setPersonLevel(level);
+			setFormData((prev) => ({
+				...prev,
+				attributes: normalizeAttributesForState(prev.attributes, level),
+			}));
+		},
+		[normalizeAttributesForState],
+	);
 
-			const initialFormData: FormData = {
-				username: user.username || "",
-				fullName: user.firstName || user.attributes?.fullname?.[0] || "",
-				email: user.email || "",
-				personnelSecurityLevel: user.attributes?.personnel_security_level?.[0] || "",
-				department: user.attributes?.department?.[0] || "",
-				position: user.attributes?.position?.[0] || "",
-				enabled: user.enabled ?? true,
-				emailVerified: user.emailVerified ?? false,
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+
+		if (mode === "edit" && user) {
 			const candidateLevel = (
 				user.attributes?.personnel_security_level?.[0] ||
 				user.attributes?.person_security_level?.[0] ||
@@ -277,10 +252,9 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 				? candidateLevel
 				: "NON_SECRET";
 			const normalizedAttributes = normalizeAttributesForState(user.attributes || {}, resolvedLevel);
-
 			const initialFormData: FormData = {
 				username: user.username || "",
-				fullName: user.firstName || user.lastName || "",
+				fullName: (user.firstName || user.lastName || user.attributes?.fullname?.[0] || "").trim(),
 				email: user.email || "",
 				enabled: user.enabled ?? true,
 				emailVerified: user.emailVerified ?? false,
@@ -288,6 +262,7 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 			};
 
 			setPersonLevel(resolvedLevel);
+			setUserRoles([]);
 			setFormData(initialFormData);
 			setFormState({
 				originalData: {
@@ -299,90 +274,62 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 			});
 
 			if (user.id) {
-				loadUserRoles(user.id).then((roles) => {
+				loadUserRoles(user.id).then((fetchedRoles) => {
 					setFormState((prev) => ({
 						...prev,
-						originalRoles: roles,
+						originalRoles: fetchedRoles,
 					}));
 				});
 			}
 		} else {
-			const emptyData = createEmptyFormData();
-			setFormData(emptyData);
 			const defaultLevel = "NON_SECRET";
 			const baseAttributes = normalizeAttributesForState({}, defaultLevel);
-			setPersonLevel(defaultLevel);
-			setFormData({
+			const emptyData: FormData = {
 				username: "",
 				fullName: "",
 				email: "",
 				enabled: true,
 				emailVerified: false,
 				attributes: baseAttributes,
-			});
+			};
+
+			setPersonLevel(defaultLevel);
+			setUserRoles([]);
+			setFormData(emptyData);
 			setFormState({
 				originalData: {
-					username: "",
-					fullName: "",
-					email: "",
-					enabled: true,
-					emailVerified: false,
-					attributes: baseAttributes,
+					...emptyData,
+					attributes: { ...emptyData.attributes },
 				},
 				originalRoles: [],
 				roleChanges: [],
 			});
-			setUserRoles([]);
 		}
+
 		setError("");
 		setRoleError("");
-	}, [mode, user, loadUserRoles, normalizeAttributesForState]);
+	}, [open, mode, user, loadUserRoles, normalizeAttributesForState]);
 
-	// 加载所有角色
 	useEffect(() => {
-		if (open) {
-			loadRoles();
-			loadUserProfileConfig(); // 加载UserProfile配置
+		if (!open) {
+			return;
 		}
+
+		loadRoles();
+		loadUserProfileConfig();
 	}, [open, loadRoles, loadUserProfileConfig]);
 
-	const buildAttributesPayload = () => {
-		const attributes: Record<string, string[]> = { ...formData.attributes };
-
-		const customAttributes: Array<{
-			key: CustomUserAttributeKey;
-			value: string;
-			originalValue: string;
-		}> = [
-			{
-				key: "personnel_security_level",
-				value: formData.personnelSecurityLevel,
-				originalValue: formState.originalData.personnelSecurityLevel,
-			},
-			{
-				key: "department",
-				value: formData.department.trim(),
-				originalValue: formState.originalData.department,
-			},
-			{
-				key: "position",
-				value: formData.position.trim(),
-				originalValue: formState.originalData.position,
-			},
-		];
-
-		customAttributes.forEach(({ key, value, originalValue }) => {
-			const normalizedOriginal = originalValue.trim();
-			if (value) {
-				attributes[key] = [value];
-			} else if (normalizedOriginal) {
-				attributes[key] = [];
-			} else {
-				delete attributes[key];
-			}
-		});
-
-		return attributes;
+	const hasUserInfoChanged = (normalizedAttributes?: Record<string, string[]>): boolean => {
+		const { originalData } = formState;
+		const attributesToCompare = normalizedAttributes ?? buildAttributesPayload();
+		return (
+			formData.username !== originalData.username ||
+			formData.email !== originalData.email ||
+			formData.fullName !== originalData.fullName ||
+			formData.enabled !== originalData.enabled ||
+			formData.emailVerified !== originalData.emailVerified ||
+			JSON.stringify(attributesToCompare) !== JSON.stringify(originalData.attributes)
+		);
 	};
 
 	const handleSubmit = async () => {
@@ -400,54 +347,37 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 			return;
 		}
 
-		// 检查UserProfile中的必填字段
+		const attributesPayload = buildAttributesPayload();
+
 		if (userProfileConfig?.attributes) {
 			for (const attribute of userProfileConfig.attributes) {
-				// 跳过基础字段，因为它们已经在上面检查过了
-				if (
-					["username", "email", "firstName", "lastName", "fullName", "department", "position"].includes(attribute.name)
-				) {
+				if (RESERVED_PROFILE_ATTRIBUTE_NAMES.includes(attribute.name)) {
 					continue;
 				}
 
-				// 检查是否为必填字段
 				if (attribute.required) {
-					const value = formData.attributes[attribute.name];
-					// 检查值是否为空
-					if (
-						!value ||
-						(Array.isArray(value) && (value.length === 0 || value.every((v) => v === ""))) ||
-						(typeof value === "string" && (!(value as string).trim() || (value as string) === ""))
-					) {
-						console.log(attribute.displayName);
-						setError(`"${t(attribute.displayName.replace(/\$\{([^}]*)\}/g, "$1")) || attribute.name}" 是必填字段`);
+					const value = attributesPayload[attribute.name];
+					if (!value || value.length === 0) {
+						const displayName = attribute.displayName.replace(/\$\{([^}]*)\}/g, "$1");
+						setError(`"${t(displayName) || attribute.name}" 是必填字段`);
 						return;
 					}
 				}
 			}
 		}
 
-		// 检查是否有任何变更
-		const hasUserInfoChanges = hasUserInfoChanged();
+		const hasUserInfoChanges = hasUserInfoChanged(attributesPayload);
 		const hasRoleChanges = formState.roleChanges.length > 0;
 
-		// 如果没有任何变更，显示提示信息
-		if (!hasUserInfoChanges && !hasRoleChanges) {
+		if (mode === "edit" && !hasUserInfoChanges && !hasRoleChanges) {
 			toast.info("没有检测到任何变更");
 			return;
 		}
 
 		setLoading(true);
 		setError("");
-		const attributesPayload = buildAttributesPayload();
 
 		try {
-			const username = formData.username.trim();
-			const fullName = formData.fullName.trim();
-			const email = formData.email.trim();
-			const attributesPayload = buildAttributesPayload();
-			const emailPayload = email || (formState.originalData.email ? "" : undefined);
-
 			if (mode === "create") {
 				const createData: CreateUserRequest = {
 					username,
@@ -458,10 +388,6 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 					attributes: attributesPayload,
 				};
 
-				if (email) {
-					createData.email = email;
-				}
-
 				const response = await KeycloakUserService.createUser(createData);
 				if (response.userId) {
 					toast.success("用户创建请求已提交，等待审批");
@@ -469,18 +395,13 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 					toast.success("用户创建请求提交成功");
 				}
 			} else if (mode === "edit" && user?.id) {
-				// 分别处理用户信息变更和角色变更
-				const hasUserInfoChanges = hasUserInfoChanged();
-				const hasRoleChanges = formState.roleChanges.length > 0;
+				const emailPayload = email || (formState.originalData.email ? "" : undefined);
 
-				// 如果有用户信息变更，提交用户信息更新请求
 				if (hasUserInfoChanges) {
 					const updateData: UpdateUserRequest = {
 						id: user.id,
 						username,
 						email: emailPayload,
-						firstName: fullName,
-						email,
 						firstName: fullName,
 						enabled: formData.enabled,
 						emailVerified: formData.emailVerified,
@@ -495,9 +416,7 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 					}
 				}
 
-				// 如果有角色变更，提交角色变更请求
 				if (hasRoleChanges) {
-					// 处理添加的角色
 					const rolesToAdd = formState.roleChanges.filter((rc) => rc.action === "add").map((rc) => rc.role);
 
 					if (rolesToAdd.length > 0) {
@@ -509,7 +428,6 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 						}
 					}
 
-					// 处理移除的角色
 					const rolesToRemove = formState.roleChanges.filter((rc) => rc.action === "remove").map((rc) => rc.role);
 
 					if (rolesToRemove.length > 0) {
@@ -530,22 +448,6 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 		} finally {
 			setLoading(false);
 		}
-	};
-
-	// 检查用户信息是否有变更
-	const hasUserInfoChanged = (): boolean => {
-		const { originalData } = formState;
-		const normalizedAttributes = buildAttributesPayload();
-		return (
-			formData.username !== originalData.username ||
-			formData.email !== originalData.email ||
-			formData.fullName !== originalData.fullName ||
-			formData.personnelSecurityLevel !== originalData.personnelSecurityLevel ||
-			formData.department !== originalData.department ||
-			formData.enabled !== originalData.enabled ||
-			formData.emailVerified !== originalData.emailVerified ||
-			JSON.stringify(normalizedAttributes) !== JSON.stringify(originalData.attributes || {})
-		);
 	};
 
 	const resolveRoleBadgeVariant = (
@@ -600,7 +502,6 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 
 	const departmentValue = formData.attributes.department?.[0] ?? "";
 	const positionValue = formData.attributes.position?.[0] ?? "";
-
 	const title = mode === "create" ? "创建用户" : "编辑用户";
 
 	return (
@@ -617,7 +518,6 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 						</Alert>
 					)}
 
-					{/* 基本信息 */}
 					<Card>
 						<CardHeader>
 							<CardTitle className="text-lg">基本信息</CardTitle>
@@ -629,19 +529,15 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 									<Input
 										id="username"
 										value={formData.username}
-										onChange={(e) => setFormData((prev) => ({ ...prev, username: e.target.value }))}
+										onChange={(e) =>
+											setFormData((prev) => ({
+												...prev,
+												username: e.target.value,
+											}))
+										}
 										placeholder="请输入用户名"
 									/>
 									<p className="text-xs text-muted-foreground">用户名即登录名，需要保持唯一。</p>
-								</div>
-								<div className="space-y-2">
-									<Label htmlFor="fullName">姓名 *</Label>
-									<Input
-										id="fullName"
-										value={formData.fullName}
-										onChange={(e) => setFormData((prev) => ({ ...prev, fullName: e.target.value }))}
-										placeholder="请输入姓名"
-									/>
 								</div>
 								<div className="space-y-2">
 									<Label htmlFor="fullName">姓名 *</Label>
@@ -657,116 +553,53 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 										placeholder="请输入姓名"
 									/>
 								</div>
-							</div>
+								<div className="space-y-2">
 									<Label htmlFor="email">邮箱</Label>
 									<Input
 										id="email"
 										type="email"
 										value={formData.email}
-										onChange={(e) => setFormData((prev) => ({ ...prev, email: e.target.value }))}
+										onChange={(e) =>
+											setFormData((prev) => ({
+												...prev,
+												email: e.target.value,
+											}))
+										}
 										placeholder="请输入邮箱（可选）"
 									/>
 									<p className="text-xs text-muted-foreground">邮箱用于接收通知，可选填写。</p>
 								</div>
 								<div className="space-y-2">
-									<Label htmlFor="personnelSecurityLevel">人员密级</Label>
-									<Select
-										value={formData.personnelSecurityLevel || undefined}
-										onValueChange={(value) =>
-											setFormData((prev) => ({
-												...prev,
-												personnelSecurityLevel: value,
-											}))
-										}
-									>
-										<SelectTrigger id="personnelSecurityLevel" className="w-full">
-											<SelectValue placeholder="请选择人员密级" />
-										</SelectTrigger>
-										<SelectContent>
-											{PERSONNEL_SECURITY_LEVEL_OPTIONS.map((option) => (
-												<SelectItem key={option} value={option}>
-													{option}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</div>
-							</div>
-								<div className="space-y-2">
 									<Label htmlFor="department">部门</Label>
 									<Input
 										id="department"
-										value={formData.department}
-										onChange={(e) =>
-											setFormData((prev) => ({
-												...prev,
-												department: e.target.value,
-											}))
-										}
-										placeholder={`例如：${DEPARTMENT_SUGGESTIONS.join("、")}`}
-
 										value={departmentValue}
 										onChange={(e) => updateSingleValueAttribute("department", e.target.value)}
-										placeholder="例如：研究所、财务、二级部门A"
+										placeholder={`例如：${DEPARTMENT_SUGGESTIONS.join("、")}`}
 									/>
 								</div>
 								<div className="space-y-2">
 									<Label htmlFor="position">职位</Label>
 									<Input
 										id="position"
-										value={formData.position}
-										onChange={(e) =>
-											setFormData((prev) => ({
-												...prev,
-												position: e.target.value,
-											}))
-										}
 										value={positionValue}
 										onChange={(e) => updateSingleValueAttribute("position", e.target.value)}
-										placeholder="例如：所长、副所长、财务主管"
+										placeholder={`例如：${POSITION_SUGGESTIONS.join("、")}`}
 									/>
 								</div>
 							</div>
-
-							{/* UserProfile字段 (基于realm配置) */}
-							{userProfileConfig?.attributes && userProfileConfig.attributes.length > 0 && (
-								<div className="">
-									{profileLoading ? (
-										<div className="flex items-center justify-center py-4">
-											<Icon icon="mdi:loading" className="animate-spin mr-2" />
-											<span>加载配置中...</span>
-										</div>
-									) : (
-										<div className="grid grid-cols-2 gap-4">
-											{userProfileConfig.attributes
-												.filter((attr) => !RESERVED_PROFILE_ATTRIBUTE_NAMES.includes(attr.name))
-												.map((attribute) => (
-													<UserProfileField
-														key={attribute.name}
-														attribute={attribute}
-														value={formData.attributes[attribute.name]}
-														onChange={(value) => {
-															setFormData((prev) => ({
-																...prev,
-																attributes: {
-																	...prev.attributes,
-																	[attribute.name]: Array.isArray(value) ? value : [value],
-																},
-															}));
-														}}
-													/>
-												))}
-										</div>
-									)}
-								</div>
-							)}
 
 							<div className="grid grid-cols-2 gap-4">
 								<div className="flex items-center space-x-2">
 									<Switch
 										id="enabled"
 										checked={formData.enabled}
-										onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, enabled: checked }))}
+										onCheckedChange={(checked) =>
+											setFormData((prev) => ({
+												...prev,
+												enabled: checked,
+											}))
+										}
 									/>
 									<Label htmlFor="enabled">启用用户</Label>
 								</div>
@@ -774,7 +607,12 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 									<Switch
 										id="emailVerified"
 										checked={formData.emailVerified}
-										onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, emailVerified: checked }))}
+										onCheckedChange={(checked) =>
+											setFormData((prev) => ({
+												...prev,
+												emailVerified: checked,
+											}))
+										}
 									/>
 									<Label htmlFor="emailVerified">邮箱已验证</Label>
 								</div>
@@ -789,7 +627,7 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 						<CardContent className="space-y-4">
 							<div className="space-y-2">
 								<Label>人员密级 *</Label>
-								<Select value={personLevel} onValueChange={(value) => setPersonLevel(value)}>
+								<Select value={personLevel} onValueChange={handlePersonLevelChange}>
 									<SelectTrigger className="w-full justify-between">
 										<SelectValue placeholder="请选择人员密级" />
 									</SelectTrigger>
@@ -823,7 +661,36 @@ export default function UserModal({ open, mode, user, onCancel, onSuccess }: Use
 							</div>
 						</CardContent>
 					</Card>
-					{/* 角色分配 (仅编辑模式) */}
+
+					<Card>
+						<CardHeader>
+							<CardTitle className="text-lg">扩展属性</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{profileLoading ? (
+								<div className="flex items-center text-sm text-muted-foreground">
+									<Icon icon="mdi:loading" className="animate-spin mr-2" />
+									<span>加载配置中...</span>
+								</div>
+							) : userProfileConfig?.attributes ? (
+								<div className="grid grid-cols-2 gap-4">
+									{userProfileConfig.attributes
+										.filter((attr) => !RESERVED_PROFILE_ATTRIBUTE_NAMES.includes(attr.name))
+										.map((attribute) => (
+											<UserProfileField
+												key={attribute.name}
+												attribute={attribute}
+												value={formData.attributes[attribute.name]}
+												onChange={(value) => handleProfileFieldChange(attribute.name, value)}
+											/>
+										))}
+								</div>
+							) : (
+								<p className="text-sm text-muted-foreground">暂无额外属性配置。</p>
+							)}
+						</CardContent>
+					</Card>
+
 					{mode === "edit" && user?.id && (
 						<Card>
 							<CardHeader>


### PR DESCRIPTION
## Summary
- correct the user table columns to show trimmed names, department, position, and normalized security level labels
- rebuild the user management modal to normalize attribute data, handle personnel level changes, validate required fields, and streamline the UI layout

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d38815a120832aa63e6cba6bdce897