### PR TITLE
fix: add missing group management route

### DIFF
--- a/src/routes/sections/dashboard/frontend.tsx
+++ b/src/routes/sections/dashboard/frontend.tsx
@@ -23,6 +23,7 @@ export function getFrontendDashboardRoutes(): RouteObject[] {
 						{ index: true, element: <Navigate to="user" replace /> },
 						{ path: "permission", element: Component("/pages/management/system/permission") },
 						{ path: "role", element: Component("/pages/management/system/role") },
+						{ path: "group", element: Component("/pages/management/system/group") },
 						{ path: "user", element: Component("/pages/management/system/user") },
 						{ path: "user/:id", element: Component("/pages/management/system/user/detail") },
 						{ path: "approval", element: Component("/pages/management/system/approval") },


### PR DESCRIPTION
## Summary
- add the group management child route to the frontend dashboard router so the navigation link no longer hits the 404 page

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d3a24faa38832ab14743f65f25d973