### PR TITLE
fix: normalize admin role menus

### DIFF
--- a/src/admin/config/menus.ts
+++ b/src/admin/config/menus.ts
@@ -1,4 +1,4 @@
-import type { AdminRole } from "@/admin/types";
+import { normalizeAdminRole, type AdminRole } from "@/admin/types";
 
 export interface AdminMenuItem {
 	key: string;
@@ -11,6 +11,7 @@ const sysadminMenus: AdminMenuItem[] = [
 	{ key: "org", label: "组织机构", path: "orgs", icon: "solar:buildings-outline" },
 	{ key: "users", label: "用户管理", path: "users", icon: "solar:users-group-outline" },
 	{ key: "roles", label: "角色管理", path: "roles", icon: "solar:shield-user-bold" },
+	{ key: "approval", label: "任务审批", path: "approval", icon: "solar:verify-outline" },
 	{ key: "ops", label: "系统运维", path: "ops", icon: "solar:settings-outline" },
 	{ key: "portal-menus", label: "业务端菜单管理", path: "portal-menus", icon: "solar:list-bold" },
 	{ key: "mine", label: "我发起的变更", path: "drafts", icon: "solar:inbox-outline" },
@@ -22,8 +23,9 @@ const authadminMenus: AdminMenuItem[] = [
 
 const auditMenus: AdminMenuItem[] = [{ key: "audit", label: "日志记录", path: "audit", icon: "solar:history-bold" }];
 
-export function getMenusByRole(role: AdminRole): AdminMenuItem[] {
-	switch (role) {
+export function getMenusByRole(role: AdminRole | string | null | undefined): AdminMenuItem[] {
+	const normalized = normalizeAdminRole(role);
+	switch (normalized) {
 		case "SYSADMIN":
 			return sysadminMenus;
 		case "AUTHADMIN":

--- a/src/admin/lib/guard.tsx
+++ b/src/admin/lib/guard.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/admin/api/adminApi";
 import { AdminSessionContext } from "@/admin/lib/session-context";
 import ForbiddenView from "@/admin/views/forbidden";
-import type { AdminRole } from "@/admin/types";
+import { normalizeAdminRole } from "@/admin/types";
 import { useRouter } from "@/routes/hooks";
 import { useSignOut } from "@/store/userStore";
 import { LineLoading } from "@/components/loading";
@@ -35,15 +35,18 @@ export default function AdminGuard({ children }: Props) {
 
 	useEffect(() => {
 		if (isLoading) return;
-		if (isError || !data?.allowed || !data.role) {
+		const normalizedRole = normalizeAdminRole(data?.role);
+		if (isError || !data?.allowed || !normalizedRole) {
 			handleForbidden();
 		}
 	}, [data, handleForbidden, isError, isLoading]);
 
 	const session = useMemo(() => {
-		if (!data?.allowed || !data.role) return null;
+		if (!data?.allowed) return null;
+		const normalizedRole = normalizeAdminRole(data.role);
+		if (!normalizedRole) return null;
 		return {
-			role: data.role as AdminRole,
+			role: normalizedRole,
 			username: data.username,
 			email: data.email,
 		};

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -2,9 +2,29 @@ export type AdminRole = "SYSADMIN" | "AUTHADMIN" | "AUDITADMIN";
 
 export interface AdminWhoami {
 	allowed: boolean;
-	role?: AdminRole;
+	role?: string | null;
 	username?: string;
 	email?: string;
+}
+
+export function normalizeAdminRole(role: string | null | undefined): AdminRole | null {
+	if (!role) {
+		return null;
+	}
+	const normalized = role.trim().toUpperCase();
+	switch (normalized) {
+		case "SYSADMIN":
+		case "SYS_ADMIN":
+			return "SYSADMIN";
+		case "AUTHADMIN":
+		case "AUTH_ADMIN":
+			return "AUTHADMIN";
+		case "AUDITADMIN":
+		case "AUDIT_ADMIN":
+			return "AUDITADMIN";
+		default:
+			return null;
+	}
 }
 
 export interface ChangeRequest {


### PR DESCRIPTION
## Summary
- normalize admin role values before building the session context to ensure guards and menus reflect the active account
- add the "任务审批" item to the sysadmin navigation and reuse role normalization when resolving role-specific menus

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d3b6577bd4832abe39cac7bd2d833c