### PR TITLE
feat: improve admin profile experience

### DIFF
--- a/src/_mock/handlers/_user.ts
+++ b/src/_mock/handlers/_user.ts
@@ -14,7 +14,7 @@ const ADMIN_ACCOUNTS = [
 		username: "sysadmin",
 		email: "sysadmin@example.com",
 		role: "SYSADMIN" as const,
-		displayName: "系统管理员",
+		fullName: "系统管理员",
 		permissions: ["user.create", "user.update", "org.manage", "config.manage"],
 	},
 	{
@@ -22,7 +22,7 @@ const ADMIN_ACCOUNTS = [
 		username: "authadmin",
 		email: "authadmin@example.com",
 		role: "AUTHADMIN" as const,
-		displayName: "授权管理员",
+		fullName: "授权管理员",
 		permissions: ["approval.review", "approval.assign"],
 	},
 	{
@@ -30,7 +30,7 @@ const ADMIN_ACCOUNTS = [
 		username: "auditadmin",
 		email: "auditadmin@example.com",
 		role: "AUDITADMIN" as const,
-		displayName: "安全审计员",
+		fullName: "安全审计员",
 		permissions: ["audit.read", "audit.export"],
 	},
 ];
@@ -66,7 +66,8 @@ const signIn = http.post(`/api${UserApi.SignIn}`, async ({ request }) => {
 				id: account.id,
 				email: account.email,
 				username: account.username,
-				firstName: account.displayName,
+				firstName: account.fullName,
+				fullName: account.fullName,
 				avatar: `https://avatars.dicebear.com/api/initials/${account.username}.svg`,
 				enabled: true,
 				roles: [account.role],

--- a/src/admin/views/audit-center.tsx
+++ b/src/admin/views/audit-center.tsx
@@ -23,7 +23,43 @@ interface FilterState {
 	ip?: string;
 }
 
+const OPERATOR_LABEL_MAP: Record<string, string> = {
+	sysadmin: "系统管理员",
+	authadmin: "授权管理员",
+	auditadmin: "安全审计员",
+};
+
 const auditLogSamples: AuditLogEntry[] = [
+	{
+		id: "L-202405-021",
+		timestamp: "2024-05-14T08:35:00+08:00",
+		module: "安全审计",
+		action: "巡检完成 日志留存验证",
+		operator: "auditadmin",
+		ip: "10.10.7.6",
+		result: "成功",
+		detail: "完成凌晨巡检并确认日志留存完整可追溯。",
+	},
+	{
+		id: "L-202405-022",
+		timestamp: "2024-05-14T08:55:00+08:00",
+		module: "安全审计",
+		action: "触发风险告警复核",
+		operator: "auditadmin",
+		ip: "10.10.7.6",
+		result: "成功",
+		detail: "复核 AI 风控规则命中的异常登录告警，判定为误报。",
+	},
+	{
+		id: "L-202405-023",
+		timestamp: "2024-05-14T09:20:00+08:00",
+		module: "安全审计",
+		action: "导出审计报表",
+		operator: "auditadmin",
+		ip: "10.10.7.8",
+		result: "成功",
+		detail: "生成近 24 小时关键操作审计报表并发送至安全负责人。",
+	},
 	{
 		id: "L-202405-001",
 		timestamp: "2024-05-12T09:05:00+08:00",
@@ -370,7 +406,7 @@ export default function AuditCenterView() {
 											<div className="text-xs text-muted-foreground">{log.detail}</div>
 										</td>
 										<td className="px-4 py-3 text-xs text-muted-foreground">
-											<div>操作者：{log.operator}</div>
+											<div>操作者：{formatOperatorName(log.operator)}</div>
 											<div>IP：{log.ip}</div>
 										</td>
 										<td className="px-4 py-3">
@@ -393,4 +429,12 @@ function formatDateTime(value: string) {
 		return value;
 	}
 	return date.toLocaleString("zh-CN", { hour12: false });
+}
+
+function formatOperatorName(value: string) {
+	const label = OPERATOR_LABEL_MAP[value as keyof typeof OPERATOR_LABEL_MAP];
+	if (label) {
+		return `${label}（${value}）`;
+	}
+	return value;
 }

--- a/src/layouts/components/account-dropdown.tsx
+++ b/src/layouts/components/account-dropdown.tsx
@@ -17,7 +17,7 @@ import {
  */
 export default function AccountDropdown() {
 	const { replace } = useRouter();
-	const { username, email, avatar } = useUserInfo();
+	const { username, email, avatar, fullName } = useUserInfo();
 	const signOut = useSignOut();
 	const { backToLogin } = useLoginStateContext();
 	const { t } = useTranslation();
@@ -44,16 +44,14 @@ export default function AccountDropdown() {
 				<div className="flex items-center gap-2 p-2">
 					<img className="h-10 w-10 rounded-full" src={avatar} alt="" />
 					<div className="flex flex-col items-start">
-						<div className="text-text-primary text-sm font-medium">{username}</div>
-						<div className="text-text-secondary text-xs">{email}</div>
+						<div className="text-text-primary text-sm font-medium">{fullName || username}</div>
+						<div className="text-text-secondary text-xs">
+							{email}
+							{username ? `（${username}）` : null}
+						</div>
 					</div>
 				</div>
 				<DropdownMenuSeparator />
-				<DropdownMenuItem asChild>
-					<NavLink to="https://docs-admin.slashspaces.com/" target="_blank">
-						{t("sys.docs")}
-					</NavLink>
-				</DropdownMenuItem>
 				<DropdownMenuItem asChild>
 					<NavLink to="/management/user/profile">{t("sys.nav.user.profile")}</NavLink>
 				</DropdownMenuItem>

--- a/src/locales/lang/en_US/sys.json
+++ b/src/locales/lang/en_US/sys.json
@@ -142,7 +142,7 @@
 			"user": {
 				"account": "Account",
 				"index": "User",
-				"profile": "Profile"
+				"profile": "Personal Details"
 			},
 			"workbench": "Workbench",
 			"dataSecurity": "Data Security",

--- a/src/locales/lang/zh_CN/sys.json
+++ b/src/locales/lang/zh_CN/sys.json
@@ -122,7 +122,7 @@
 			"user": {
 				"account": "账户",
 				"index": "用户",
-				"profile": "个人资料"
+				"profile": "个人详情"
 			},
 			"dataSecurity": "数据安全",
 			"dataSecurityOverview": "资产概览",

--- a/src/pages/management/user/profile/index.tsx
+++ b/src/pages/management/user/profile/index.tsx
@@ -1,18 +1,54 @@
 import type { CSSProperties } from "react";
+import { useMemo } from "react";
 import bannerImage from "@/assets/images/background/banner-1.png";
 import { Icon } from "@/components/icon";
 import { useUserInfo } from "@/store/userStore";
 import { themeVars } from "@/theme/theme.css";
 import { Avatar, AvatarImage } from "@/ui/avatar";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
 import { Text, Title } from "@/ui/typography";
-import ConnectionsTab from "./connections-tab";
 import ProfileTab from "./profile-tab";
-import ProjectsTab from "./projects-tab";
-import TeamsTab from "./teams-tab";
+
+const ROLE_LABEL_MAP: Record<string, string> = {
+	SYSADMIN: "系统管理员",
+	AUTHADMIN: "授权管理员",
+	AUDITADMIN: "安全审计员",
+};
+
+function resolveRoleLabels(roles: unknown): string[] {
+	if (!Array.isArray(roles) || roles.length === 0) {
+		return [];
+	}
+
+	return roles
+		.map((role) => {
+			if (typeof role === "string") {
+				return ROLE_LABEL_MAP[role] ?? role;
+			}
+
+			if (role && typeof role === "object") {
+				const maybeRole = role as { code?: string; name?: string };
+				const key = maybeRole.code || maybeRole.name;
+				if (key) {
+					return ROLE_LABEL_MAP[key] ?? key;
+				}
+			}
+
+			return undefined;
+		})
+		.filter((item): item is string => Boolean(item));
+}
 
 function UserProfile() {
-	const { avatar, username } = useUserInfo();
+	const { avatar, fullName, firstName, username, email, roles } = useUserInfo();
+
+	const resolvedName = fullName || firstName || username || "";
+	const roleLabels = useMemo(() => {
+		const labels = resolveRoleLabels(roles);
+		if (labels.length > 0) {
+			return Array.from(new Set(labels));
+		}
+		return [];
+	}, [roles]);
 
 	const bgStyle: CSSProperties = {
 		position: "absolute",
@@ -23,63 +59,41 @@ function UserProfile() {
 		backgroundRepeat: "no-repeat",
 	};
 
-	const tabs = [
-		{
-			icon: <Icon icon="solar:user-id-bold" size={24} className="mr-2" />,
-			title: "Profile",
-			content: <ProfileTab />,
-		},
-		{
-			icon: <Icon icon="mingcute:profile-fill" size={24} className="mr-2" />,
-			title: "Teams",
-			content: <TeamsTab />,
-		},
-		{
-			icon: <Icon icon="mingcute:profile-fill" size={24} className="mr-2" />,
-			title: "Projects",
-			content: <ProjectsTab />,
-		},
-		{
-			icon: <Icon icon="mingcute:profile-fill" size={24} className="mr-2" />,
-			title: "Connections",
-			content: <ConnectionsTab />,
-		},
-	];
-
 	return (
-		<Tabs defaultValue={tabs[0].title} className="w-full">
-			<div className="relative flex flex-col justify-center items-center gap-4 p-4">
-				<div style={bgStyle} className="h-full w-full z-1" />
-				<div className="flex flex-col items-center justify-center gap-2 z-2">
-					<Avatar className="h-24 w-24">
+		<div className="space-y-6">
+			<div className="relative flex flex-col items-center gap-4 p-6 text-center">
+				<div style={bgStyle} className="absolute inset-0 rounded-lg" />
+				<div className="absolute inset-0 rounded-lg bg-black/40" />
+				<div className="relative z-10 flex flex-col items-center gap-3">
+					<Avatar className="h-24 w-24 border-4 border-background shadow-lg">
 						<AvatarImage src={avatar} className="rounded-full" />
 					</Avatar>
-					<div className="flex flex-col justify-center items-center gap-2">
+					<div className="flex flex-col items-center gap-1">
 						<div className="flex items-center gap-2">
-							<Title as="h5" className="text-xl">
-								{username}
+							<Title as="h5" className="text-xl text-background">
+								{resolvedName}
 							</Title>
-							<Icon icon="heroicons:check-badge-solid" size={20} color={themeVars.colors.palette.primary.default} />
+							<Icon icon="heroicons:check-badge-solid" size={20} color={themeVars.colors.palette.success.default} />
 						</div>
-						<Text variant="body2">TS FullStack</Text>
+						{username ? (
+							<Text variant="body3" className="text-background/80">
+								登录账号：{username}
+							</Text>
+						) : null}
+						<Text variant="body2" className="text-background">
+							{roleLabels.length ? roleLabels.join("、") : "管理员"}
+						</Text>
+						{email ? (
+							<Text variant="body3" className="text-background/80">
+								联系邮箱：{email}
+							</Text>
+						) : null}
 					</div>
 				</div>
-				<TabsList className="z-5">
-					{tabs.map((tab) => (
-						<TabsTrigger key={tab.title} value={tab.title}>
-							{tab.icon}
-							{tab.title}
-						</TabsTrigger>
-					))}
-				</TabsList>
 			</div>
 
-			{tabs.map((tab) => (
-				<TabsContent key={tab.title} value={tab.title}>
-					{tab.content}
-				</TabsContent>
-			))}
-		</Tabs>
+			<ProfileTab />
+		</div>
 	);
 }
 

--- a/src/pages/management/user/profile/profile-tab.tsx
+++ b/src/pages/management/user/profile/profile-tab.tsx
@@ -1,281 +1,81 @@
-import { faker } from "@faker-js/faker";
-import { Timeline } from "antd";
-import { Icon } from "@/components/icon";
+import { useMemo } from "react";
 import { useUserInfo } from "@/store/userStore";
-import { themeVars } from "@/theme/theme.css";
-import { Badge } from "@/ui/badge";
-import { Button } from "@/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/ui/card";
 import { Text } from "@/ui/typography";
 
+const ROLE_LABEL_MAP: Record<string, string> = {
+	SYSADMIN: "系统管理员",
+	AUTHADMIN: "授权管理员",
+	AUDITADMIN: "安全审计员",
+};
+
+function resolveRoleLabels(roles: unknown): string[] {
+	if (!Array.isArray(roles) || roles.length === 0) {
+		return [];
+	}
+
+	return roles
+		.map((role) => {
+			if (typeof role === "string") {
+				return ROLE_LABEL_MAP[role] ?? role;
+			}
+
+			if (role && typeof role === "object") {
+				const maybeRole = role as { code?: string; name?: string };
+				const key = maybeRole.code || maybeRole.name;
+				if (key) {
+					return ROLE_LABEL_MAP[key] ?? key;
+				}
+			}
+
+			return undefined;
+		})
+		.filter((item): item is string => Boolean(item));
+}
+
 export default function ProfileTab() {
-	const { username } = useUserInfo();
-	const AboutItems = [
-		{
-			icon: <Icon icon="fa-solid:user" size={18} />,
-			label: "Full Name",
-			val: username,
-		},
-		{
-			icon: <Icon icon="eos-icons:role-binding" size={18} />,
-			label: "Role",
-			val: "Developer",
-		},
-		{
-			icon: <Icon icon="tabler:location-filled" size={18} />,
-			label: "Country",
-			val: "USA",
-		},
-		{
-			icon: <Icon icon="ion:language" size={18} />,
-			label: "Language",
-			val: "English",
-		},
-		{
-			icon: <Icon icon="ph:phone-fill" size={18} />,
-			label: "Contact",
-			val: "(123)456-7890",
-		},
-		{
-			icon: <Icon icon="ic:baseline-email" size={18} />,
-			label: "Email",
-			val: username,
-		},
-	];
+	const { fullName, firstName, username, email, roles, enabled, id } = useUserInfo();
 
-	const ConnectionsItems = [
-		{
-			avatar: faker.image.avatarGitHub(),
-			name: faker.person.fullName(),
-			connections: `${faker.number.int(100)} Connections`,
-			connected: faker.datatype.boolean(),
-		},
+	const resolvedName = fullName || firstName || username || "-";
+	const roleLabels = useMemo(() => {
+		const labels = resolveRoleLabels(roles);
+		if (labels.length > 0) {
+			return Array.from(new Set(labels));
+		}
+		return [];
+	}, [roles]);
 
-		{
-			avatar: faker.image.avatarGitHub(),
-			name: faker.person.fullName(),
-			connections: `${faker.number.int(100)} Connections`,
-			connected: faker.datatype.boolean(),
-		},
-
-		{
-			avatar: faker.image.avatarGitHub(),
-			name: faker.person.fullName(),
-			connections: `${faker.number.int(100)} Connections`,
-			connected: faker.datatype.boolean(),
-		},
-
-		{
-			avatar: faker.image.avatarGitHub(),
-			name: faker.person.fullName(),
-			connections: `${faker.number.int(100)} Connections`,
-			connected: faker.datatype.boolean(),
-		},
-
-		{
-			avatar: faker.image.avatarGitHub(),
-			name: faker.person.fullName(),
-			connections: `${faker.number.int(100)} Connections`,
-			connected: faker.datatype.boolean(),
-		},
-	];
-
-	const TeamItems = [
-		{
-			avatar: <Icon icon="devicon:react" size={36} />,
-			name: "React Developers",
-			members: `${faker.number.int(100)} Members`,
-			tag: <Badge variant="warning">Developer</Badge>,
-		},
-		{
-			avatar: <Icon icon="devicon:figma" size={36} />,
-			name: "UI Designer",
-			members: `${faker.number.int()} Members`,
-			tag: <Badge variant="info">Designer</Badge>,
-		},
-		{
-			avatar: <Icon icon="logos:jest" size={36} />,
-			name: "Test Team",
-			members: `${faker.number.int(100)} Members`,
-			tag: <Badge variant="success">Test</Badge>,
-		},
-		{
-			avatar: <Icon icon="logos:nestjs" size={36} />,
-			name: "Nest.js Developers",
-			members: `${faker.number.int(100)} Members`,
-			tag: <Badge variant="warning">Developer</Badge>,
-		},
-
-		{
-			avatar: <Icon icon="logos:twitter" size={36} />,
-			name: "Digital Marketing",
-			members: `${faker.number.int(100)} Members`,
-			tag: <Badge variant="info">Marketing</Badge>,
-		},
+	const basicInfo = [
+		{ label: "姓名", value: resolvedName },
+		{ label: "用户名", value: username || "-" },
+		{ label: "邮箱", value: email || "-" },
+		{ label: "角色", value: roleLabels.length ? roleLabels.join("、") : "-" },
+		{ label: "账号状态", value: enabled === false ? "已停用" : "正常" },
+		{ label: "账号标识", value: id || "-" },
 	];
 
 	return (
-		<div className="flex flex-col gap-4">
-			<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-				<Card className="col-span-1">
-					<CardHeader>
-						<CardTitle>About</CardTitle>
-						<CardDescription>{faker.lorem.paragraph()}</CardDescription>
-					</CardHeader>
-					<CardContent>
-						<div className="flex flex-col gap-4">
-							{AboutItems.map((item) => (
-								<div className="flex" key={item.label}>
-									<div className="mr-2">{item.icon}</div>
-									<div className="mr-2">{item.label}:</div>
-									<div className="opacity-50">{item.val}</div>
-								</div>
-							))}
+		<Card>
+			<CardHeader className="space-y-1">
+				<CardTitle>基本信息</CardTitle>
+				<Text variant="body3" className="text-muted-foreground">
+					查看当前登录管理员的基础资料和账号状态。
+				</Text>
+			</CardHeader>
+			<CardContent>
+				<dl className="grid gap-4 sm:grid-cols-2">
+					{basicInfo.map((item) => (
+						<div key={item.label} className="space-y-1">
+							<Text variant="body3" className="text-muted-foreground">
+								{item.label}
+							</Text>
+							<Text variant="body2" className="font-medium text-foreground">
+								{item.value}
+							</Text>
 						</div>
-					</CardContent>
-				</Card>
-
-				<Card className="col-span-1 md:col-span-2">
-					<CardHeader>
-						<CardTitle>Activity Timeline</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<Timeline
-							className="mt-4! w-full"
-							items={[
-								{
-									color: themeVars.colors.palette.error.default,
-									children: (
-										<div className="flex flex-col">
-											<div className="flex items-center justify-between">
-												<Text>8 Invoices have been paid</Text>
-												<div className="opacity-50">Wednesday</div>
-											</div>
-											<Text variant="caption" color="secondary">
-												Invoices have been paid to the company.
-											</Text>
-
-											<div className="mt-2 flex items-center gap-2">
-												<Icon icon="local:file-pdf" size={30} />
-												<span className="font-medium opacity-60">invoice.pdf</span>
-											</div>
-										</div>
-									),
-								},
-								{
-									color: themeVars.colors.palette.primary.default,
-									children: (
-										<div className="flex flex-col">
-											<div className="flex items-center justify-between">
-												<Text>Create a new project for client 😎</Text>
-												<div className="opacity-50">April, 18</div>
-											</div>
-											<Text variant="caption" color="secondary">
-												Invoices have been paid to the company.
-											</Text>
-											<div className="mt-2 flex items-center gap-2">
-												<img alt="" src={faker.image.avatarGitHub()} className="h-8 w-8 rounded-full" />
-												<span className="font-medium opacity-60">{faker.person.fullName()} (client)</span>
-											</div>
-										</div>
-									),
-								},
-								{
-									color: themeVars.colors.palette.info.default,
-									children: (
-										<div className="flex flex-col">
-											<div className="flex items-center justify-between">
-												<Text>Order #37745 from September</Text>
-												<div className="opacity-50">January, 10</div>
-											</div>
-											<Text variant="caption" color="secondary">
-												Invoices have been paid to the company.
-											</Text>
-										</div>
-									),
-								},
-								{
-									color: themeVars.colors.palette.warning.default,
-									children: (
-										<div className="flex flex-col">
-											<div className="flex items-center justify-between">
-												<Text>Public Meeting</Text>
-												<div className="opacity-50">September, 30</div>
-											</div>
-										</div>
-									),
-								},
-							]}
-						/>
-					</CardContent>
-				</Card>
-			</div>
-			<div className="flex flex-col md:flex-row gap-4">
-				<div className="flex-1">
-					<Card>
-						<CardHeader>
-							<CardTitle className="w-full flex items-center justify-between">
-								<span>Connections</span>
-								<Button variant="ghost" size="icon">
-									<Icon icon="fontisto:more-v-a" />
-								</Button>
-							</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<div className="flex w-full flex-col gap-4">
-								{ConnectionsItems.map((item) => (
-									<div className="flex" key={item.name}>
-										<img alt="" src={item.avatar} className="h-10 w-10 flex-none rounded-full" />
-										<div className="ml-4 flex flex-1 flex-col">
-											<span className="font-semibold">{item.name}</span>
-											<span className="mt-1 text-xs opacity-50">{item.connections}</span>
-										</div>
-										<div
-											className="flex h-8 w-8 flex-none items-center justify-center rounded"
-											style={{
-												backgroundColor: item.connected ? themeVars.colors.palette.primary.default : "transparent",
-												border: item.connected ? "" : `1px solid ${themeVars.colors.palette.primary.default}`,
-											}}
-										>
-											<Icon
-												icon="tdesign:user"
-												color={item.connected ? "#fff" : themeVars.colors.palette.primary.default}
-												size={20}
-											/>
-										</div>
-									</div>
-								))}
-							</div>
-						</CardContent>
-					</Card>
-				</div>
-				<div className="flex-1">
-					<Card>
-						<CardHeader>
-							<div className="flex items-center justify-between">
-								<CardTitle>Teams</CardTitle>
-								<Button variant="ghost" size="icon">
-									<Icon icon="fontisto:more-v-a" />
-								</Button>
-							</div>
-						</CardHeader>
-						<CardContent>
-							<div className="flex w-full flex-col gap-4">
-								{TeamItems.map((item) => (
-									<div className="flex" key={item.name}>
-										{item.avatar}
-										<div className="ml-4 flex flex-1 flex-col">
-											<span className="font-semibold">{item.name}</span>
-											<span className="mt-1 text-xs opacity-50">{item.members}</span>
-										</div>
-										<div className="h-6">{item.tag}</div>
-									</div>
-								))}
-							</div>
-						</CardContent>
-					</Card>
-				</div>
-			</div>
-		</div>
+					))}
+				</dl>
+			</CardContent>
+		</Card>
 	);
 }

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -67,6 +67,8 @@ export const useSignIn = () => {
 			const { user, accessToken, refreshToken } = res;
 
 			// 适配后端数据格式：处理角色和权限信息
+			const resolvedFullName = user.fullName || user.firstName || user.lastName || user.username || "";
+
 			const adaptedUser = {
 				...user,
 				// 处理角色信息 - 保持字符串数组格式
@@ -76,7 +78,8 @@ export const useSignIn = () => {
 				// 为用户设置默认头像
 				avatar: user.avatar || "/src/assets/icons/ic-user.svg",
 				// 确保必要的字段存在
-				firstName: user.firstName || "",
+				firstName: user.firstName || resolvedFullName,
+				fullName: resolvedFullName,
 				lastName: user.lastName || "",
 				email: user.email || "",
 				enabled: user.enabled !== undefined ? user.enabled : true,

--- a/src/types/entity.ts
+++ b/src/types/entity.ts
@@ -13,6 +13,7 @@ export interface UserInfo {
 	password?: string;
 	avatar?: string;
 	firstName?: string;
+	fullName?: string;
 	lastName?: string;
 	enabled?: boolean;
 	roles?: Role[] | string[]; // 支持两种格式：对象数组或字符串数组


### PR DESCRIPTION
## Summary
- ensure admin mock accounts expose localized full names and surface them through user state and the avatar dropdown
- rename the personal profile menu to "Personal Details" and redesign the page so it only shows the signed-in admin's basic information
- seed additional audit log samples for auditadmin and display localized operator labels in the log table

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d3cb96cbe8832a9845486df5260cdd