### PR TITLE
feat: optimize org and access management

### DIFF
--- a/src/_mock/db/keycloak.ts
+++ b/src/_mock/db/keycloak.ts
@@ -8,7 +8,7 @@ const roles: KeycloakRole[] = [
 		composite: true,
 		clientRole: false,
 		containerId: "realm",
-		attributes: { category: "核心" },
+		attributes: { category: "核心", dataSecurityLevel: "DATA_TOP_SECRET" },
 	},
 	{
 		id: "role-authadmin",
@@ -17,6 +17,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_SECRET" },
 	},
 	{
 		id: "role-auditadmin",
@@ -25,6 +26,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_SECRET" },
 	},
 	{
 		id: "role-dept-owner",
@@ -33,6 +35,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_SECRET" },
 	},
 	{
 		id: "role-dept-editor",
@@ -41,6 +44,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_INTERNAL" },
 	},
 	{
 		id: "role-dept-viewer",
@@ -49,6 +53,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_PUBLIC" },
 	},
 	{
 		id: "role-inst-owner",
@@ -57,6 +62,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_TOP_SECRET" },
 	},
 	{
 		id: "role-inst-editor",
@@ -65,6 +71,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_SECRET" },
 	},
 	{
 		id: "role-inst-viewer",
@@ -73,6 +80,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_INTERNAL" },
 	},
 	{
 		id: "role-data-steward",
@@ -81,6 +89,7 @@ const roles: KeycloakRole[] = [
 		composite: false,
 		clientRole: false,
 		containerId: "realm",
+		attributes: { dataSecurityLevel: "DATA_INTERNAL" },
 	},
 ];
 

--- a/src/_mock/handlers/_keycloak.ts
+++ b/src/_mock/handlers/_keycloak.ts
@@ -451,9 +451,11 @@ const keycloakHandlers = [
 		}
 		const payload = (await request.json()) as UpdateRoleRequest;
 		const current = keycloakDb.roles[index];
+		const nextAttributes = payload.attributes ? { ...current.attributes, ...payload.attributes } : current.attributes;
 		keycloakDb.roles[index] = {
 			...current,
 			...payload,
+			attributes: nextAttributes,
 			name: payload.name ?? current.name,
 		};
 		return ok(keycloakDb.roles[index], "角色更新成功");

--- a/src/constants/governance.ts
+++ b/src/constants/governance.ts
@@ -16,6 +16,18 @@ export const GOVERNANCE_ROLE_NAMES = ["ROLE_SYS_ADMIN", "ROLE_AUTH_ADMIN", "ROLE
 export const APPLICATION_ROLE_NAMES = ["ROLE_OP_ADMIN"] as const;
 export const DATA_ROLE_NAMES = ["DATA_PUBLIC", "DATA_INTERNAL", "DATA_SECRET", "DATA_TOP_SECRET"] as const;
 
+export const DATA_SECURITY_LEVEL_LABELS: Record<(typeof DATA_ROLE_NAMES)[number], string> = {
+	DATA_PUBLIC: "公开",
+	DATA_INTERNAL: "内部",
+	DATA_SECRET: "秘密",
+	DATA_TOP_SECRET: "机密",
+};
+
+export const DATA_SECURITY_LEVEL_OPTIONS = (DATA_ROLE_NAMES as readonly string[]).map((value) => ({
+	value,
+	label: DATA_SECURITY_LEVEL_LABELS[value as (typeof DATA_ROLE_NAMES)[number]],
+}));
+
 export function deriveDataLevels(level?: string | null): string[] {
 	if (!level) return [];
 	return DATA_LEVELS_BY_PERSON_LEVEL[level] ?? [];

--- a/src/pages/management/system/group/index.tsx
+++ b/src/pages/management/system/group/index.tsx
@@ -33,7 +33,7 @@ export default function GroupPage() {
 	const [filteredTree, setFilteredTree] = useState<GroupTreeNode[]>([]);
 	const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
 	const [autoExpandParent, setAutoExpandParent] = useState(true);
-	const [selectedKeys, setSelectedKeys] = useState<Key[]>([]);
+	const [selectedKey, setSelectedKey] = useState<Key | null>(null);
 	const [selectedGroup, setSelectedGroup] = useState<GroupTableRow | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [searchValue, setSearchValue] = useState("");
@@ -59,7 +59,7 @@ export default function GroupPage() {
 
 	const loadGroups = useCallback(async () => {
 		setLoading(true);
-		const currentSelectedKey = selectedKeys[0];
+		const currentSelectedKey = selectedKey ?? null;
 		try {
 			const groupsData = await KeycloakGroupService.getAllGroups();
 			const allGroups = flattenGroups(groupsData);
@@ -87,20 +87,20 @@ export default function GroupPage() {
 			if (currentSelectedKey) {
 				const found = findNodeByKey(tree, currentSelectedKey);
 				if (found) {
-					setSelectedKeys([found.key]);
+					setSelectedKey((prev) => (prev === found.key ? prev : found.key));
 					setSelectedGroup(found.group);
 				} else if (tree[0]) {
-					setSelectedKeys([tree[0].key]);
+					setSelectedKey(tree[0].key);
 					setSelectedGroup(tree[0].group);
 				} else {
-					setSelectedKeys([]);
+					setSelectedKey(null);
 					setSelectedGroup(null);
 				}
 			} else if (tree[0]) {
-				setSelectedKeys([tree[0].key]);
+				setSelectedKey(tree[0].key);
 				setSelectedGroup(tree[0].group);
 			} else {
-				setSelectedKeys([]);
+				setSelectedKey(null);
 				setSelectedGroup(null);
 			}
 		} catch (error: any) {
@@ -109,7 +109,7 @@ export default function GroupPage() {
 		} finally {
 			setLoading(false);
 		}
-	}, [selectedKeys]);
+	}, [selectedKey]);
 
 	useEffect(() => {
 		if (!searchValue.trim()) {
@@ -194,9 +194,10 @@ export default function GroupPage() {
 											setExpandedKeys(keys);
 											setAutoExpandParent(false);
 										}}
-										selectedKeys={selectedKeys}
+										selectedKeys={selectedKey ? [selectedKey] : []}
 										onSelect={(keys, info) => {
-											setSelectedKeys(keys);
+											const nextKey = (keys[0] as Key | undefined) ?? null;
+											setSelectedKey(nextKey);
 											setSelectedGroup(info.node.group ?? null);
 										}}
 									/>

--- a/src/pages/management/system/role/role-assign-modal.tsx
+++ b/src/pages/management/system/role/role-assign-modal.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import type { KeycloakRole, KeycloakUser } from "#/keycloak";
+import { KeycloakUserService } from "@/api/services/keycloakService";
+import { Badge } from "@/ui/badge";
+import { Button } from "@/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/ui/dialog";
+import { Input } from "@/ui/input";
+import { Label } from "@/ui/label";
+import { ScrollArea } from "@/ui/scroll-area";
+import { Text } from "@/ui/typography";
+
+interface RoleAssignModalProps {
+	open: boolean;
+	role?: KeycloakRole;
+	onCancel: () => void;
+	onSuccess: () => void;
+}
+
+export default function RoleAssignModal({ open, role, onCancel, onSuccess }: RoleAssignModalProps) {
+	const [users, setUsers] = useState<KeycloakUser[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
+	const [search, setSearch] = useState("");
+	const [selectedUserId, setSelectedUserId] = useState<string>("");
+
+	const loadUsers = useCallback(async () => {
+		setLoading(true);
+		try {
+			const list = await KeycloakUserService.getAllUsers({ max: 200 });
+			setUsers(list);
+		} catch (error: any) {
+			console.error("Error loading users for role assignment:", error);
+			toast.error(`加载用户列表失败: ${error?.message || "未知错误"}`);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+		setSearch("");
+		setSelectedUserId("");
+		void loadUsers();
+	}, [loadUsers, open]);
+
+	const filteredUsers = useMemo(() => {
+		if (!search.trim()) {
+			return users;
+		}
+		const keyword = search.trim().toLowerCase();
+		return users.filter((user) => {
+			return [user.username, user.firstName, user.lastName, user.email]
+				.filter(Boolean)
+				.some((field) => field?.toLowerCase().includes(keyword));
+		});
+	}, [search, users]);
+
+	const selectedUser = useMemo(() => {
+		if (!selectedUserId) return null;
+		return users.find((user) => user.id === selectedUserId || user.username === selectedUserId) ?? null;
+	}, [selectedUserId, users]);
+
+	const handleAssign = async () => {
+		if (!role?.name) {
+			toast.error("角色信息缺失，无法分配");
+			return;
+		}
+		if (!selectedUser) {
+			toast.error("请选择需要分配的用户");
+			return;
+		}
+		setSubmitting(true);
+		try {
+			await KeycloakUserService.assignRolesToUser(selectedUser.id ?? selectedUser.username, [
+				{ id: role.id, name: role.name },
+			]);
+			toast.success(`已为 ${selectedUser.username} 分配角色 ${role.name}`);
+			onSuccess();
+		} catch (error: any) {
+			console.error("Error assigning role:", error);
+			toast.error(`角色分配失败: ${error?.message || "未知错误"}`);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const handleOpenChange = (value: boolean) => {
+		if (!value && !submitting) {
+			onCancel();
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="max-w-xl">
+				<DialogHeader>
+					<DialogTitle>角色分配</DialogTitle>
+				</DialogHeader>
+				<div className="space-y-4">
+					<div className="space-y-1">
+						<Label>待分配角色</Label>
+						<div className="rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 px-3 py-2 text-sm">
+							{role?.name ?? "未选择角色"}
+						</div>
+					</div>
+					<div className="space-y-2">
+						<Label htmlFor="role-assign-search">搜索用户</Label>
+						<Input
+							id="role-assign-search"
+							placeholder="输入用户名/姓名/邮箱"
+							value={search}
+							onChange={(event) => setSearch(event.target.value)}
+							disabled={loading}
+						/>
+					</div>
+					<div className="space-y-2">
+						<Label>选择用户</Label>
+						<div className="rounded-md border">
+							<ScrollArea className="h-60">
+								{loading ? (
+									<div className="flex h-full items-center justify-center text-sm text-muted-foreground">加载中...</div>
+								) : filteredUsers.length === 0 ? (
+									<div className="p-4 text-sm text-muted-foreground">未找到匹配的用户。</div>
+								) : (
+									<ul className="divide-y">
+										{filteredUsers.map((user) => {
+											const key = user.id ?? user.username;
+											const isActive = selectedUserId === (user.id ?? user.username);
+											return (
+												<li key={key}>
+													<button
+														type="button"
+														onClick={() => setSelectedUserId(user.id ?? user.username)}
+														className={`flex w-full items-start justify-between gap-4 px-4 py-3 text-left text-sm transition ${
+															isActive ? "bg-primary/10" : "hover:bg-muted"
+														}`}
+													>
+														<div className="flex-1 space-y-1">
+															<div className="font-medium">{user.username}</div>
+															<Text variant="body3" className="text-muted-foreground">
+																{[user.firstName, user.lastName].filter(Boolean).join(" ") || "--"}
+															</Text>
+															<Text variant="body3" className="text-muted-foreground">
+																{user.email || "未填写邮箱"}
+															</Text>
+															{user.realmRoles && user.realmRoles.length > 0 ? (
+																<div className="flex flex-wrap gap-1 pt-1">
+																	{user.realmRoles.map((roleName) => (
+																		<Badge key={roleName} variant="outline">
+																			{roleName}
+																		</Badge>
+																	))}
+																</div>
+															) : null}
+														</div>
+														<div className="pt-1 text-xs text-muted-foreground">{isActive ? "已选择" : "点击选择"}</div>
+													</button>
+												</li>
+											);
+										})}
+									</ul>
+								)}
+							</ScrollArea>
+						</div>
+					</div>
+				</div>
+				<DialogFooter>
+					<Button variant="outline" onClick={onCancel} disabled={submitting}>
+						取消
+					</Button>
+					<Button onClick={handleAssign} disabled={!selectedUser || submitting}>
+						{submitting ? "分配中..." : "确认分配"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/types/keycloak.ts
+++ b/src/types/keycloak.ts
@@ -181,6 +181,7 @@ export interface PaginationParams {
  */
 export interface UserTableRow extends KeycloakUser {
 	key: string;
+	roleNames?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix the organization tree selection loop by tracking the active node with a single key
- enrich user management with role aggregation and display
- streamline role management to focus on realm roles, capture required data security levels, seed mock data, and add a role assignment modal

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d505cbffc0832a80dae02d8e0636d6